### PR TITLE
Update EXPLAIN links.

### DIFF
--- a/guides/source/active_record_querying.md
+++ b/guides/source/active_record_querying.md
@@ -1732,8 +1732,8 @@ EXPLAIN for: SELECT `posts`.* FROM `posts`  WHERE `posts`.`user_id` IN (1)
 
 EXPLAINの出力を解釈することは、本ガイドの範疇を超えます。以下の情報を参考にしてください。
 
-* SQLite3: [EXPLAIN QUERY PLAN](http://www.sqlite.org/eqp.html)
+* SQLite3: [EXPLAIN QUERY PLAN (英語)](http://www.sqlite.org/eqp.html)
 
-* MySQL: [EXPLAIN Output Format](http://dev.mysql.com/doc/refman/5.6/en/explain-output.html)
+* MySQL: [EXPLAIN Output Format (英語)](http://dev.mysql.com/doc/refman/5.6/en/explain-output.html)
 
-* PostgreSQL: [Using EXPLAIN](http://www.postgresql.org/docs/current/static/using-explain.html)
+* PostgreSQL: [EXPLAINの利用 (日本語)](https://www.postgresql.jp/document/9.3/html/using-explain.html)


### PR DESCRIPTION
過去の 892223a の修正を参考にEXPLAINのPostgreSQL向けのリンクを日本語のページに修正してみました。MySQLのリンクもあるのではないかと思って手を付けたのですが、/ja/以下そのものが404になってしまってたのでPostgreSQLだけになってしまいました...PostgreSQLだけでもよければマージしてやってください。