### PR TITLE
Fix #151 Footerに各記事の一覧を追加

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -10,6 +10,7 @@
 .snsb {
     overflow: hidden;
     clear: left;
+    margin-left: 13px;
 }
 .snsb li {
     float: left;

--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -9,6 +9,7 @@
 
 .snsb {
     overflow: hidden;
+    clear: left;
 }
 .snsb li {
     float: left;
@@ -18,7 +19,22 @@
 .snsb iframe {
     margin: 0 !important;
 }
-     
+.sitemap{
+  margin-left: 13px;
+}
+.sitemap .L, .sitemap .C, .sitemap .R {
+  float: left;
+  width: 33%;
+  margin: 0;
+  padding: 0;
+}
+@media screen and (max-width: 880px) {
+  .sitemap .L, .sitemap .C, .sitemap .R { width: 50%; }
+}
+@media screen and (max-width: 480px) {
+  .sitemap .L, .sitemap .C, .sitemap .R { width: 100%; }
+}
+
 .left {float: left; margin-right: 1em;}
 .right {float: right; margin-left: 1em;}
 @media screen and (max-width: 480px) {

--- a/guides/output/2_2_release_notes.html
+++ b/guides/output/2_2_release_notes.html
@@ -805,6 +805,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -838,7 +898,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/2_2_release_notes.html
+++ b/guides/output/2_2_release_notes.html
@@ -865,16 +865,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/2_3_release_notes.html
+++ b/guides/output/2_3_release_notes.html
@@ -993,6 +993,66 @@ rake rails:template LOCATION=~/template.rb
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1026,7 +1086,7 @@ rake rails:template LOCATION=~/template.rb
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/2_3_release_notes.html
+++ b/guides/output/2_3_release_notes.html
@@ -1053,16 +1053,16 @@ rake rails:template LOCATION=~/template.rb
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/3_0_release_notes.html
+++ b/guides/output/3_0_release_notes.html
@@ -953,16 +953,16 @@ User.validators_on(:login)
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/3_0_release_notes.html
+++ b/guides/output/3_0_release_notes.html
@@ -893,6 +893,66 @@ User.validators_on(:login)
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -926,7 +986,7 @@ User.validators_on(:login)
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/3_1_release_notes.html
+++ b/guides/output/3_1_release_notes.html
@@ -798,6 +798,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -831,7 +891,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/3_1_release_notes.html
+++ b/guides/output/3_1_release_notes.html
@@ -858,16 +858,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/3_2_release_notes.html
+++ b/guides/output/3_2_release_notes.html
@@ -911,16 +911,16 @@ ActiveSupport::BufferedLogger.new f
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/3_2_release_notes.html
+++ b/guides/output/3_2_release_notes.html
@@ -851,6 +851,66 @@ ActiveSupport::BufferedLogger.new f
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -884,7 +944,7 @@ ActiveSupport::BufferedLogger.new f
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/4_0_release_notes.html
+++ b/guides/output/4_0_release_notes.html
@@ -637,16 +637,16 @@ store :settings, accessors: [ :color, :homepage ], coder: JSON
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/4_0_release_notes.html
+++ b/guides/output/4_0_release_notes.html
@@ -577,6 +577,66 @@ store :settings, accessors: [ :color, :homepage ], coder: JSON
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -610,7 +670,7 @@ store :settings, accessors: [ :color, :homepage ], coder: JSON
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/4_1_release_notes.html
+++ b/guides/output/4_1_release_notes.html
@@ -719,6 +719,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -752,7 +812,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/4_1_release_notes.html
+++ b/guides/output/4_1_release_notes.html
@@ -779,16 +779,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/4_2_release_notes.html
+++ b/guides/output/4_2_release_notes.html
@@ -915,6 +915,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -948,7 +1008,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/4_2_release_notes.html
+++ b/guides/output/4_2_release_notes.html
@@ -975,16 +975,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/_license.html
+++ b/guides/output/_license.html
@@ -306,16 +306,16 @@
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/_license.html
+++ b/guides/output/_license.html
@@ -246,6 +246,66 @@
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -279,7 +339,7 @@
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/_welcome.html
+++ b/guides/output/_welcome.html
@@ -312,16 +312,16 @@ Rails 3.0用のガイドについては<a href="http://wiki.usagee.co.jp/ruby/ra
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/_welcome.html
+++ b/guides/output/_welcome.html
@@ -252,6 +252,66 @@ Rails 3.0用のガイドについては<a href="http://wiki.usagee.co.jp/ruby/ra
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -285,7 +345,7 @@ Rails 3.0用のガイドについては<a href="http://wiki.usagee.co.jp/ruby/ra
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/action_controller_overview.html
+++ b/guides/output/action_controller_overview.html
@@ -1413,6 +1413,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1446,7 +1506,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/action_controller_overview.html
+++ b/guides/output/action_controller_overview.html
@@ -1473,16 +1473,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/action_mailer_basics.html
+++ b/guides/output/action_mailer_basics.html
@@ -941,6 +941,66 @@ ActionMailer::Base.register_interceptor(SandboxEmailInterceptor) if Rails.env.st
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -974,7 +1034,7 @@ ActionMailer::Base.register_interceptor(SandboxEmailInterceptor) if Rails.env.st
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/action_mailer_basics.html
+++ b/guides/output/action_mailer_basics.html
@@ -1001,16 +1001,16 @@ ActionMailer::Base.register_interceptor(SandboxEmailInterceptor) if Rails.env.st
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/action_view_overview.html
+++ b/guides/output/action_view_overview.html
@@ -1866,6 +1866,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1899,7 +1959,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/action_view_overview.html
+++ b/guides/output/action_view_overview.html
@@ -1926,16 +1926,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/active_job_basics.html
+++ b/guides/output/active_job_basics.html
@@ -519,6 +519,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -552,7 +612,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/active_job_basics.html
+++ b/guides/output/active_job_basics.html
@@ -579,16 +579,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/active_model_basics.html
+++ b/guides/output/active_model_basics.html
@@ -459,6 +459,66 @@ person.valid? # =&gt; ActiveModel::StrictValidationFailedが発生する
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -492,7 +552,7 @@ person.valid? # =&gt; ActiveModel::StrictValidationFailedが発生する
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/active_model_basics.html
+++ b/guides/output/active_model_basics.html
@@ -519,16 +519,16 @@ person.valid? # =&gt; ActiveModel::StrictValidationFailedが発生する
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/active_record_basics.html
+++ b/guides/output/active_record_basics.html
@@ -630,16 +630,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/active_record_basics.html
+++ b/guides/output/active_record_basics.html
@@ -570,6 +570,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -603,7 +663,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/active_record_callbacks.html
+++ b/guides/output/active_record_callbacks.html
@@ -663,6 +663,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -696,7 +756,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/active_record_callbacks.html
+++ b/guides/output/active_record_callbacks.html
@@ -723,16 +723,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/active_record_migrations.html
+++ b/guides/output/active_record_migrations.html
@@ -1077,6 +1077,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1110,7 +1170,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/active_record_migrations.html
+++ b/guides/output/active_record_migrations.html
@@ -1137,16 +1137,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/active_record_querying.html
+++ b/guides/output/active_record_querying.html
@@ -2131,16 +2131,16 @@ EXPLAIN for: SELECT `posts`.* FROM `posts`  WHERE `posts`.`user_id` IN (1)
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/active_record_querying.html
+++ b/guides/output/active_record_querying.html
@@ -2071,6 +2071,66 @@ EXPLAIN for: SELECT `posts`.* FROM `posts`  WHERE `posts`.`user_id` IN (1)
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -2104,7 +2164,7 @@ EXPLAIN for: SELECT `posts`.* FROM `posts`  WHERE `posts`.`user_id` IN (1)
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/active_record_validations.html
+++ b/guides/output/active_record_validations.html
@@ -1299,16 +1299,16 @@ person.errors.size # =&gt; 0
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/active_record_validations.html
+++ b/guides/output/active_record_validations.html
@@ -1239,6 +1239,66 @@ person.errors.size # =&gt; 0
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1272,7 +1332,7 @@ person.errors.size # =&gt; 0
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/active_support_core_extensions.html
+++ b/guides/output/active_support_core_extensions.html
@@ -4092,16 +4092,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/active_support_core_extensions.html
+++ b/guides/output/active_support_core_extensions.html
@@ -4032,6 +4032,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -4065,7 +4125,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/active_support_instrumentation.html
+++ b/guides/output/active_support_instrumentation.html
@@ -1234,16 +1234,16 @@ If you application is sending Tweets, you should create an event named <code>twe
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/active_support_instrumentation.html
+++ b/guides/output/active_support_instrumentation.html
@@ -1174,6 +1174,66 @@ If you application is sending Tweets, you should create an event named <code>twe
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1207,7 +1267,7 @@ If you application is sending Tweets, you should create an event named <code>twe
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/api_documentation_guidelines.html
+++ b/guides/output/api_documentation_guidelines.html
@@ -567,6 +567,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -600,7 +660,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/api_documentation_guidelines.html
+++ b/guides/output/api_documentation_guidelines.html
@@ -627,16 +627,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/asset_pipeline.html
+++ b/guides/output/asset_pipeline.html
@@ -1170,6 +1170,66 @@ gem 'uglifier'
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1203,7 +1263,7 @@ gem 'uglifier'
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/asset_pipeline.html
+++ b/guides/output/asset_pipeline.html
@@ -1230,16 +1230,16 @@ gem 'uglifier'
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/association_basics.html
+++ b/guides/output/association_basics.html
@@ -2430,16 +2430,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/association_basics.html
+++ b/guides/output/association_basics.html
@@ -2370,6 +2370,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -2403,7 +2463,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/caching_with_rails.html
+++ b/guides/output/caching_with_rails.html
@@ -645,6 +645,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -678,7 +738,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/caching_with_rails.html
+++ b/guides/output/caching_with_rails.html
@@ -705,16 +705,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/command_line.html
+++ b/guides/output/command_line.html
@@ -898,6 +898,66 @@ development:
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -931,7 +991,7 @@ development:
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/command_line.html
+++ b/guides/output/command_line.html
@@ -958,16 +958,16 @@ development:
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/configuring.html
+++ b/guides/output/configuring.html
@@ -1166,16 +1166,16 @@ ActiveRecord::ConnectionTimeoutError - could not obtain a database connection wi
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/configuring.html
+++ b/guides/output/configuring.html
@@ -1106,6 +1106,66 @@ ActiveRecord::ConnectionTimeoutError - could not obtain a database connection wi
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1139,7 +1199,7 @@ ActiveRecord::ConnectionTimeoutError - could not obtain a database connection wi
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/constant_autoloading_and_reloading.html
+++ b/guides/output/constant_autoloading_and_reloading.html
@@ -1219,6 +1219,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1252,7 +1312,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/constant_autoloading_and_reloading.html
+++ b/guides/output/constant_autoloading_and_reloading.html
@@ -1279,16 +1279,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/contributing_to_ruby_on_rails.html
+++ b/guides/output/contributing_to_ruby_on_rails.html
@@ -750,6 +750,66 @@ $ git apply ~/my_changes.patch
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -783,7 +843,7 @@ $ git apply ~/my_changes.patch
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/contributing_to_ruby_on_rails.html
+++ b/guides/output/contributing_to_ruby_on_rails.html
@@ -810,16 +810,16 @@ $ git apply ~/my_changes.patch
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/credits.html
+++ b/guides/output/credits.html
@@ -364,16 +364,16 @@ Oscar Del Ben is a software engineer at <a href="http://www.wildfireapp.com/">Wi
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/credits.html
+++ b/guides/output/credits.html
@@ -304,6 +304,66 @@ Oscar Del Ben is a software engineer at <a href="http://www.wildfireapp.com/">Wi
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -337,7 +397,7 @@ Oscar Del Ben is a software engineer at <a href="http://www.wildfireapp.com/">Wi
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/debugging_rails_applications.html
+++ b/guides/output/debugging_rails_applications.html
@@ -1077,6 +1077,66 @@ db時間、レンダリング時間、トータル時間、パラメータリス
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1110,7 +1170,7 @@ db時間、レンダリング時間、トータル時間、パラメータリス
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/debugging_rails_applications.html
+++ b/guides/output/debugging_rails_applications.html
@@ -1137,16 +1137,16 @@ db時間、レンダリング時間、トータル時間、パラメータリス
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/development_dependencies_install.html
+++ b/guides/output/development_dependencies_install.html
@@ -559,6 +559,66 @@ $ bundle exec rake db:drop
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -592,7 +652,7 @@ $ bundle exec rake db:drop
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/development_dependencies_install.html
+++ b/guides/output/development_dependencies_install.html
@@ -619,16 +619,16 @@ $ bundle exec rake db:drop
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/engines.html
+++ b/guides/output/engines.html
@@ -1319,16 +1319,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/engines.html
+++ b/guides/output/engines.html
@@ -1259,6 +1259,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1292,7 +1352,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/form_helpers.html
+++ b/guides/output/form_helpers.html
@@ -1323,16 +1323,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/form_helpers.html
+++ b/guides/output/form_helpers.html
@@ -1263,6 +1263,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1296,7 +1356,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/generators.html
+++ b/guides/output/generators.html
@@ -954,6 +954,66 @@ readme "README"
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -987,7 +1047,7 @@ readme "README"
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/generators.html
+++ b/guides/output/generators.html
@@ -1014,16 +1014,16 @@ readme "README"
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/getting_started.html
+++ b/guides/output/getting_started.html
@@ -1848,16 +1848,16 @@ class CommentsController &lt; ApplicationController
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/getting_started.html
+++ b/guides/output/getting_started.html
@@ -1788,6 +1788,66 @@ class CommentsController &lt; ApplicationController
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1821,7 +1881,7 @@ class CommentsController &lt; ApplicationController
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/i18n.html
+++ b/guides/output/i18n.html
@@ -1388,6 +1388,66 @@ I18n.t :foo, raise: true # always re-raises exceptions from the backend
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1421,7 +1481,7 @@ I18n.t :foo, raise: true # always re-raises exceptions from the backend
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/i18n.html
+++ b/guides/output/i18n.html
@@ -1448,16 +1448,16 @@ I18n.t :foo, raise: true # always re-raises exceptions from the backend
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/index.html
+++ b/guides/output/index.html
@@ -429,16 +429,16 @@ Ruby on Rails ガイド：体系的に Rails を学ぼう
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/index.html
+++ b/guides/output/index.html
@@ -369,6 +369,66 @@ Ruby on Rails ガイド：体系的に Rails を学ぼう
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -402,7 +462,7 @@ Ruby on Rails ガイド：体系的に Rails を学ぼう
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/initialization.html
+++ b/guides/output/initialization.html
@@ -954,16 +954,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/initialization.html
+++ b/guides/output/initialization.html
@@ -894,6 +894,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -927,7 +987,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/layout.html
+++ b/guides/output/layout.html
@@ -530,16 +530,16 @@
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>
@@ -649,16 +649,16 @@
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/layout.html
+++ b/guides/output/layout.html
@@ -470,6 +470,66 @@
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -503,7 +563,7 @@
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>
@@ -529,6 +589,66 @@
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -562,7 +682,7 @@
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/layouts_and_rendering.html
+++ b/guides/output/layouts_and_rendering.html
@@ -1814,16 +1814,16 @@ Cache-Control: no-cache
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/layouts_and_rendering.html
+++ b/guides/output/layouts_and_rendering.html
@@ -1754,6 +1754,66 @@ Cache-Control: no-cache
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1787,7 +1847,7 @@ Cache-Control: no-cache
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/maintenance_policy.html
+++ b/guides/output/maintenance_policy.html
@@ -283,6 +283,66 @@
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -316,7 +376,7 @@
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/maintenance_policy.html
+++ b/guides/output/maintenance_policy.html
@@ -343,16 +343,16 @@
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/migrations.html
+++ b/guides/output/migrations.html
@@ -1036,6 +1036,66 @@ class AddInitialProducts &lt; ActiveRecord::Migration
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1069,7 +1129,7 @@ class AddInitialProducts &lt; ActiveRecord::Migration
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/migrations.html
+++ b/guides/output/migrations.html
@@ -1096,16 +1096,16 @@ class AddInitialProducts &lt; ActiveRecord::Migration
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/nested_model_forms.html
+++ b/guides/output/nested_model_forms.html
@@ -477,6 +477,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -510,7 +570,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/nested_model_forms.html
+++ b/guides/output/nested_model_forms.html
@@ -537,16 +537,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/plugins.html
+++ b/guides/output/plugins.html
@@ -765,16 +765,16 @@ $ bin/rake rdoc
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/plugins.html
+++ b/guides/output/plugins.html
@@ -705,6 +705,66 @@ $ bin/rake rdoc
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -738,7 +798,7 @@ $ bin/rake rdoc
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/rails_application_templates.html
+++ b/guides/output/rails_application_templates.html
@@ -528,6 +528,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -561,7 +621,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/rails_application_templates.html
+++ b/guides/output/rails_application_templates.html
@@ -588,16 +588,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/rails_on_rack.html
+++ b/guides/output/rails_on_rack.html
@@ -606,6 +606,66 @@ config.middleware.delete "Rack::MethodOverride"
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -639,7 +699,7 @@ config.middleware.delete "Rack::MethodOverride"
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/rails_on_rack.html
+++ b/guides/output/rails_on_rack.html
@@ -666,16 +666,16 @@ config.middleware.delete "Rack::MethodOverride"
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/routing.html
+++ b/guides/output/routing.html
@@ -1895,16 +1895,16 @@ assert_routing({ path: 'photos', method: :post }, { controller: 'photos', action
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/routing.html
+++ b/guides/output/routing.html
@@ -1835,6 +1835,66 @@ assert_routing({ path: 'photos', method: :post }, { controller: 'photos', action
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1868,7 +1928,7 @@ assert_routing({ path: 'photos', method: :post }, { controller: 'photos', action
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/ruby_on_rails_guides_guidelines.html
+++ b/guides/output/ruby_on_rails_guides_guidelines.html
@@ -443,16 +443,16 @@ bundle exec rake guides:generate:kindle
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/ruby_on_rails_guides_guidelines.html
+++ b/guides/output/ruby_on_rails_guides_guidelines.html
@@ -383,6 +383,66 @@ bundle exec rake guides:generate:kindle
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -416,7 +476,7 @@ bundle exec rake guides:generate:kindle
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/security.html
+++ b/guides/output/security.html
@@ -1212,6 +1212,66 @@ config.action_dispatch.default_headers.clear
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1245,7 +1305,7 @@ config.action_dispatch.default_headers.clear
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/security.html
+++ b/guides/output/security.html
@@ -1272,16 +1272,16 @@ config.action_dispatch.default_headers.clear
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/stylesheets/main.css
+++ b/guides/output/stylesheets/main.css
@@ -10,6 +10,7 @@
 .snsb {
     overflow: hidden;
     clear: left;
+    margin-left: 13px;
 }
 .snsb li {
     float: left;

--- a/guides/output/stylesheets/main.css
+++ b/guides/output/stylesheets/main.css
@@ -9,6 +9,7 @@
 
 .snsb {
     overflow: hidden;
+    clear: left;
 }
 .snsb li {
     float: left;
@@ -18,7 +19,22 @@
 .snsb iframe {
     margin: 0 !important;
 }
-     
+.sitemap{
+  margin-left: 13px;
+}
+.sitemap .L, .sitemap .C, .sitemap .R {
+  float: left;
+  width: 33%;
+  margin: 0;
+  padding: 0;
+}
+@media screen and (max-width: 880px) {
+  .sitemap .L, .sitemap .C, .sitemap .R { width: 50%; }
+}
+@media screen and (max-width: 480px) {
+  .sitemap .L, .sitemap .C, .sitemap .R { width: 100%; }
+}
+
 .left {float: left; margin-right: 1em;}
 .right {float: right; margin-left: 1em;}
 @media screen and (max-width: 480px) {

--- a/guides/output/testing.html
+++ b/guides/output/testing.html
@@ -1518,6 +1518,66 @@ end
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1551,7 +1611,7 @@ end
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/testing.html
+++ b/guides/output/testing.html
@@ -1578,16 +1578,16 @@ end
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/upgrading_ruby_on_rails.html
+++ b/guides/output/upgrading_ruby_on_rails.html
@@ -1365,16 +1365,16 @@ $ bin/rake db:sessions:clear
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/upgrading_ruby_on_rails.html
+++ b/guides/output/upgrading_ruby_on_rails.html
@@ -1305,6 +1305,66 @@ $ bin/rake db:sessions:clear
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -1338,7 +1398,7 @@ $ bin/rake db:sessions:clear
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/output/working_with_javascript_in_rails.html
+++ b/guides/output/working_with_javascript_in_rails.html
@@ -653,16 +653,16 @@ $(document).on "page:change", -&gt;
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/output/working_with_javascript_in_rails.html
+++ b/guides/output/working_with_javascript_in_rails.html
@@ -593,6 +593,66 @@ $(document).on "page:change", -&gt;
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -626,7 +686,7 @@ $(document).on "page:change", -&gt;
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -210,16 +210,16 @@
         <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
         </dl>
       </div>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li><iframe src="http://ghbtns.com/github-btn.html?user=yasslab&repo=railsguides.jp&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="80" height="20"></iframe></li>
 	<li><a href="http://b.hatena.ne.jp/entry/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-hatena-bookmark-layout="standard-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="http://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="http://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>
 	<li><div class="fb-like" data-href="http://railsguides.jp/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></div></li>
 	<li><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://railsguides.jp/" data-text="Ruby on Rails ガイド：体系的に Rails を学ぼう (Rails 4.2 対応)" data-lang="ja" data-hashtags="Railsガイド" width="100">ツイート</a><script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script></li>
       </ol>
-      <ol class="snsb" style="margin-left: 13px">
+      <ol class="snsb">
 	<li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。</li>
 	<li>「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>
       </ol>

--- a/guides/source/layout.html.erb
+++ b/guides/source/layout.html.erb
@@ -150,6 +150,66 @@
   <hr class="hide" />
   <div id="footer">
     <div class="wrapper">
+      <div class="sitemap">
+        <dl class="L">
+        <dt>はじめに</dt>
+        <dd><a href="getting_started.html">Rails をはじめよう</a></dd>
+        <dt>モデル</dt>
+        <dd><a href="active_record_basics.html">Active Record の基礎</a></dd>
+        <dd><a href="active_record_migrations.html">Active Record マイグレーション</a></dd>
+        <dd><a href="active_record_validations.html">Active Record バリデーション</a></dd>
+        <dd><a href="active_record_callbacks.html">Active Record コールバック</a></dd>
+        <dd><a href="association_basics.html">Active Record の関連付け</a></dd>
+        <dd><a href="active_record_querying.html">Active Record クエリインターフェイス</a></dd>
+        <dd><a href="active_model_basics.html">Active Model の基礎</a></dd>
+        <dt>ビュー</dt>
+        <dd><a href="action_view_overview.html">Action View の概要</a></dd>
+        <dd><a href="layouts_and_rendering.html">レイアウトとレンダリング</a></dd>
+        <dd><a href="form_helpers.html">Action View フォームヘルパー</a></dd>
+        <dt>コントローラ</dt>
+        <dd><a href="action_controller_overview.html">Action Controller の概要</a></dd>
+        <dd><a href="routing.html">Rails ルーティング</a></dd>
+        </dl>
+        <dl class="C">
+        <dt>高度なトピック</dt>
+        <dd><a href="active_support_core_extensions.html">Active Support コア拡張機能</a></dd>
+        <dd><a href="i18n.html">Rails 国際化 (i18n) API</a></dd>
+        <dd><a href="action_mailer_basics.html">Action Mailer の基礎</a></dd>
+        <dd><a href="active_job_basics.html">Active Job の基礎</a></dd>
+        <dd><a href="testing.html">Rails テスティングガイド</a></dd>
+        <dd><a href="security.html">Rails セキュリティガイド</a></dd>
+        <dd><a href="debugging_rails_applications.html">Rails アプリケーションのデバッグ</a></dd>
+        <dd><a href="configuring.html">Rails アプリケーションを設定する</a></dd>
+        <dd><a href="command_line.html">コマンドラインツールと Rake タスク</a></dd>
+        <dd><a href="asset_pipeline.html">アセットパイプライン</a></dd>
+        <dd><a href="working_with_javascript_in_rails.html">Rails で JavaScript を使用する</a></dd>
+        <dd><a href="engines.html">Rails エンジン入門</a></dd>
+        <dd><a href="initialization.html">Rails の初期化プロセス</a></dd>
+        <dd><a href="constant_autoloading_and_reloading.html">定数の自動読み込みと再読み込み</a></dd>
+        <dt>Rails を拡張する</dt>
+        <dd><a href="plugins.html">Rails プラグイン作成入門</a></dd>
+        <dd><a href="rails_on_rack.html">Rails と Rack</a></dd>
+        <dd><a href="generators.html">Rails ジェネレータとテンプレート入門</a></dd>
+        </dl>
+        <dl class="R">
+        <dt>Ruby on Rails に貢献する</dt>
+        <dd><a href="contributing_to_ruby_on_rails.html">Contributing to Ruby on Rails [未着手]</a></dd>
+        <dd><a href="api_documentation_guidelines.html">APIドキュメント作成ガイドライン</a></dd>
+        <dd><a href="ruby_on_rails_guides_guidelines.html">Rails ガイドのガイドライン</a></dd>
+        <dt>メンテナンスポリシー</dt>
+        <dd><a href="maintenance_policy.html">メンテナンスポリシー</a></dd>
+        <dt>リリースノート</dt>
+        <dd><a href="upgrading_ruby_on_rails.html">Rails アップグレードガイド</a></dd>
+        <dd><a href="4_2_release_notes.html">Ruby on Rails 4.2 リリースノート</a></dd>
+        <dd><a href="4_1_release_notes.html">Ruby on Rails 4.1 リリースノート</a></dd>
+        <dd><a href="4_0_release_notes.html">Ruby on Rails 4.0 リリースノート</a></dd>
+        <dd><a href="3_2_release_notes.html">Ruby on Rails 3.2 Release Notes [未着手]</a></dd>
+        <dd><a href="3_1_release_notes.html">Ruby on Rails 3.1 Release Notes [未着手]</a></dd>
+        <dd><a href="3_0_release_notes.html">Ruby on Rails 3.0 Release Notes [未着手]</a></dd>
+        <dd><a href="2_3_release_notes.html">Ruby on Rails 2.3 Release Notes [未着手]</a></dd>
+        <dd><a href="2_2_release_notes.html">Ruby on Rails 2.2 Release Notes [未着手]</a></dd>
+        </dl>
+      </div>
       <ol class="snsb" style="margin-left: 13px">
 	<li><a href="http://www.railscp.org/text/" target="_blank"><img src="images/railscp_logo.png" width="150px"/></a></li>
       </ol>
@@ -183,7 +243,7 @@
     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-    
+
     ga('create', 'UA-50163209-4', 'auto');
     ga('send', 'pageview');
   </script>


### PR DESCRIPTION
Fix #151 
- サイトマップとして各記事の一覧を追加しました。

- モバイル対応は横幅`880px`より大きいの時は３列に表示し、`880px`以下`480px`未満の時は２列、`480px`以下は１列で表示するようにしました。
![2015-05-12 1 54 41](https://cloud.githubusercontent.com/assets/1221303/7570267/e3e8d21a-f849-11e4-81b4-9138174894b1.png)
