### PR TITLE
特設のページのテーブルの表示を修正

### DIFF
--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -965,6 +965,14 @@ div.code_container {
   -moz-border-radius: 5px;
   box-shadow: -5px 4px 6px rgba(166, 166, 166, 0.8);
 }
+
+#contact.section {
+  margin-top: 50px;
+}
+
+/* about seminar
+--------------------------------------- */
+
 .seminar table {
   width: 100%;
 }
@@ -1039,13 +1047,11 @@ div.code_container {
   .seminar .table.responsive { margin-bottom: 0; }
   .seminar .pinned { display: none; }
   .seminar div.table-wrapper div.scrollable table { margin-left: 0; }
-  .seminar table.responsive th:first-child, .seminar table.responsive td:first-child, .seminar table.responsive td:first-child, .seminar table.responsive.pinned td { display: table-cell; }
-
+  .seminar table.responsive th:first-child, .seminar table.responsive td:first-child, .seminar table.responsive td:first-child, .seminar table.responsive.pinned td { display: block; white-space: inherit; }
+  .seminar .state { padding: 0px; width: 100%; }
+  .seminar td { display: block; }
 }
 
-#contact.section {
-  margin-top: 50px;
-}
 
 /* Clearing
 --------------------------------------- */

--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -1044,12 +1044,15 @@ div.code_container {
 }
 
 @media only screen and (max-width: 767px) {
-  .seminar .table.responsive { margin-bottom: 0; }
-  .seminar .pinned { display: none; }
-  .seminar div.table-wrapper div.scrollable table { margin-left: 0; }
-  .seminar table.responsive th:first-child, .seminar table.responsive td:first-child, .seminar table.responsive td:first-child, .seminar table.responsive.pinned td { display: block; white-space: inherit; }
-  .seminar .state { padding: 0px; width: 100%; }
-  .seminar td { display: block; }
+  .seminar .table.responsive, .legal .table.responsive { margin-bottom: 0; white-space: inherit; }
+  .seminar .pinned, .legal .pinned { display: none; }
+  .seminar div.table-wrapper div.scrollable table,
+  .legal div.table-wrapper div.scrollable table { margin-left: 0; }
+  .seminar table.responsive th:first-child, .seminar table.responsive td:first-child, .seminar table.responsive td:first-child, .seminar table.responsive.pinned td,
+  .legal table.responsive th:first-child, .legal table.responsive td:first-child, .legal table.responsive td:first-child, .legal table.responsive.pinned td { display: block; white-space: inherit; }
+  .seminar .state, .legal .state { padding: 0px; width: 100%; }
+  .seminar td, .legal td { display: block; }
+  .legal table.responsive td, .legal table.responsive th { white-space: inherit; }
 }
 
 

--- a/guides/assets/stylesheets/main.css
+++ b/guides/assets/stylesheets/main.css
@@ -946,8 +946,8 @@ div.code_container {
   -moz-box-shadow: rgba(0,0,0,1) 0 1px 0;
   box-shadow: rgba(0,0,0,1) 0 1px 0;
   cursor: pointer;
-  width: 86%;
-  margin: 20px 30px 0px;
+  width: 90%;
+  margin: 20px 0px 0px;
   text-align: center;
 }
 

--- a/guides/output/ja/options.html
+++ b/guides/output/ja/options.html
@@ -256,7 +256,7 @@
 <div class="legal">
   <table border="0" cellpadding="9" cellspacing="1">
     <tr>
-      <th>事業者名称<br>　</th>
+      <th>事業者名称</th>
       <td><a href="http://yasslab.jp/ja/">ヤスラボ</a> (代表: 安川 要平)<br>(<a href="/policy.html">特定商取引法に基づく表記について</a>)</td>
     </tr>
     <tr>
@@ -264,7 +264,7 @@
       <td>決済サービス「Gumroad」を利用したクレジットカードまたはPayPal決済</td>
     </tr>
     <tr>
-      <th>販売価格<br>　</th>
+      <th>販売価格</th>
       <td><b><s>4,800円</s> <font color="red"> 3,800円 + 税</font><br>初回キャンペーンの価格は7月19日 23:59 まで</b></td>
     </tr>
     <tr>
@@ -276,7 +276,7 @@
       <td>Gumroad のページからダウンロードできます。</td>
     </tr>
     <tr>
-      <th>お問い合わせ<br/>　</th>
+      <th>お問い合わせ</th>
       <td>電子メールにて <i>yohei@yasslab.jp</i> または<br/>
 	下記フォームからお問い合わせください。</td>
     </tr>

--- a/guides/output/ja/options.html
+++ b/guides/output/ja/options.html
@@ -316,8 +316,8 @@
     </thead>
     <tbody>
       <tr class="available"><!-- available,full,finish-->
-        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27698"  style="color:#fff;">申し込む</a></td>
         <td>2015/07/18（土） 13:30 - 15:30 @ 東京</td>
+        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27698"  style="color:#fff;">申し込む</a></td>
       </tr>
     </tbody>
   </table>
@@ -329,8 +329,8 @@
     </thead>
     <tbody>
       <tr class="available"><!-- available,full,finish-->
-        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27773"  style="color:#fff;">申し込む</a></td>
         <td>2015/07/18（土） 16:00 - 18:00 @ 東京</td>
+        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27773"  style="color:#fff;">申し込む</a></td>
       </tr>
     </tbody>
   </table>
@@ -342,8 +342,8 @@
     </thead>
     <tbody>
       <tr class="available"><!-- available,full,finish-->
-        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27774"  style="color:#fff;">申し込む</a></td>
         <td>2015/07/19（日） 13:30 - 15:30 @ 東京</td>
+        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27774"  style="color:#fff;">申し込む</a></td>
       </tr>
     </tbody>
   </table>
@@ -355,8 +355,8 @@
     </thead>
     <tbody>
       <tr class="available"><!-- available,full,finish-->
-        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27775"  style="color:#fff;">申し込む</a></td>
         <td>2015/07/19（日） 16:00 - 18:00 @ 東京</td>
+        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27775"  style="color:#fff;">申し込む</a></td>
       </tr>
     </tbody>
   </table>
@@ -368,8 +368,8 @@
     </thead>
     <tbody>
       <tr class="available"><!-- available,full,finish-->
-        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27776"  style="color:#fff;">申し込む</a></td>
         <td>2015/07/20（月） 13:30 - 15:30 @ 東京</td>
+        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27776"  style="color:#fff;">申し込む</a></td>
       </tr>
     </tbody>
   </table>
@@ -381,8 +381,8 @@
     </thead>
     <tbody>
       <tr class="available"><!-- available,full,finish-->
-        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27777"  style="color:#fff;">申し込む</a></td>
         <td>2015/07/20（月） 16:00 - 18:00 @ 東京</td>
+        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27777"  style="color:#fff;">申し込む</a></td>
       </tr>
     </tbody>
   </table>

--- a/guides/output/ja/stylesheets/main.css
+++ b/guides/output/ja/stylesheets/main.css
@@ -965,6 +965,14 @@ div.code_container {
   -moz-border-radius: 5px;
   box-shadow: -5px 4px 6px rgba(166, 166, 166, 0.8);
 }
+
+#contact.section {
+  margin-top: 50px;
+}
+
+/* about seminar
+--------------------------------------- */
+
 .seminar table {
   width: 100%;
 }
@@ -1039,13 +1047,11 @@ div.code_container {
   .seminar .table.responsive { margin-bottom: 0; }
   .seminar .pinned { display: none; }
   .seminar div.table-wrapper div.scrollable table { margin-left: 0; }
-  .seminar table.responsive th:first-child, .seminar table.responsive td:first-child, .seminar table.responsive td:first-child, .seminar table.responsive.pinned td { display: table-cell; }
-
+  .seminar table.responsive th:first-child, .seminar table.responsive td:first-child, .seminar table.responsive td:first-child, .seminar table.responsive.pinned td { display: block; white-space: inherit; }
+  .seminar .state { padding: 0px; width: 100%; }
+  .seminar td { display: block; }
 }
 
-#contact.section {
-  margin-top: 50px;
-}
 
 /* Clearing
 --------------------------------------- */

--- a/guides/output/ja/stylesheets/main.css
+++ b/guides/output/ja/stylesheets/main.css
@@ -1044,12 +1044,15 @@ div.code_container {
 }
 
 @media only screen and (max-width: 767px) {
-  .seminar .table.responsive { margin-bottom: 0; }
-  .seminar .pinned { display: none; }
-  .seminar div.table-wrapper div.scrollable table { margin-left: 0; }
-  .seminar table.responsive th:first-child, .seminar table.responsive td:first-child, .seminar table.responsive td:first-child, .seminar table.responsive.pinned td { display: block; white-space: inherit; }
-  .seminar .state { padding: 0px; width: 100%; }
-  .seminar td { display: block; }
+  .seminar .table.responsive, .legal .table.responsive { margin-bottom: 0; white-space: inherit; }
+  .seminar .pinned, .legal .pinned { display: none; }
+  .seminar div.table-wrapper div.scrollable table,
+  .legal div.table-wrapper div.scrollable table { margin-left: 0; }
+  .seminar table.responsive th:first-child, .seminar table.responsive td:first-child, .seminar table.responsive td:first-child, .seminar table.responsive.pinned td,
+  .legal table.responsive th:first-child, .legal table.responsive td:first-child, .legal table.responsive td:first-child, .legal table.responsive.pinned td { display: block; white-space: inherit; }
+  .seminar .state, .legal .state { padding: 0px; width: 100%; }
+  .seminar td, .legal td { display: block; }
+  .legal table.responsive td, .legal table.responsive th { white-space: inherit; }
 }
 
 

--- a/guides/output/ja/stylesheets/main.css
+++ b/guides/output/ja/stylesheets/main.css
@@ -946,8 +946,8 @@ div.code_container {
   -moz-box-shadow: rgba(0,0,0,1) 0 1px 0;
   box-shadow: rgba(0,0,0,1) 0 1px 0;
   cursor: pointer;
-  width: 86%;
-  margin: 20px 30px 0px;
+  width: 90%;
+  margin: 20px 0px 0px;
   text-align: center;
 }
 

--- a/guides/source/ja/options.html.erb
+++ b/guides/source/ja/options.html.erb
@@ -34,7 +34,7 @@ yes
 <div class="legal">
   <table border="0" cellpadding="9" cellspacing="1">
     <tr>
-      <th>事業者名称<br>　</th>
+      <th>事業者名称</th>
       <td><a href="http://yasslab.jp/ja/">ヤスラボ</a> (代表: 安川 要平)<br>(<a href="/policy.html">特定商取引法に基づく表記について</a>)</td>
     </tr>
     <tr>
@@ -42,7 +42,7 @@ yes
       <td>決済サービス「Gumroad」を利用したクレジットカードまたはPayPal決済</td>
     </tr>
     <tr>
-      <th>販売価格<br>　</th>
+      <th>販売価格</th>
       <td><b><s>4,800円</s> <font color="red"> 3,800円 + 税</font><br>初回キャンペーンの価格は7月19日 23:59 まで</b></td>
     </tr>
     <tr>
@@ -54,7 +54,7 @@ yes
       <td>Gumroad のページからダウンロードできます。</td>
     </tr>
     <tr>
-      <th>お問い合わせ<br/>　</th>
+      <th>お問い合わせ</th>
       <td>電子メールにて <i>yohei@yasslab.jp</i> または<br/>
 	下記フォームからお問い合わせください。</td>
     </tr>

--- a/guides/source/ja/options.html.erb
+++ b/guides/source/ja/options.html.erb
@@ -94,8 +94,8 @@ yes
     </thead>
     <tbody>
       <tr class="available"><!-- available,full,finish-->
-        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27698"  style="color:#fff;">申し込む</a></td>
         <td>2015/07/18（土） 13:30 - 15:30 @ 東京</td>
+        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27698"  style="color:#fff;">申し込む</a></td>
       </tr>
     </tbody>
   </table>
@@ -107,8 +107,8 @@ yes
     </thead>
     <tbody>
       <tr class="available"><!-- available,full,finish-->
-        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27773"  style="color:#fff;">申し込む</a></td>
         <td>2015/07/18（土） 16:00 - 18:00 @ 東京</td>
+        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27773"  style="color:#fff;">申し込む</a></td>
       </tr>
     </tbody>
   </table>
@@ -120,8 +120,8 @@ yes
     </thead>
     <tbody>
       <tr class="available"><!-- available,full,finish-->
-        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27774"  style="color:#fff;">申し込む</a></td>
         <td>2015/07/19（日） 13:30 - 15:30 @ 東京</td>
+        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27774"  style="color:#fff;">申し込む</a></td>
       </tr>
     </tbody>
   </table>
@@ -133,8 +133,8 @@ yes
     </thead>
     <tbody>
       <tr class="available"><!-- available,full,finish-->
-        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27775"  style="color:#fff;">申し込む</a></td>
         <td>2015/07/19（日） 16:00 - 18:00 @ 東京</td>
+        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27775"  style="color:#fff;">申し込む</a></td>
       </tr>
     </tbody>
   </table>
@@ -146,8 +146,8 @@ yes
     </thead>
     <tbody>
       <tr class="available"><!-- available,full,finish-->
-        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27776"  style="color:#fff;">申し込む</a></td>
         <td>2015/07/20（月） 13:30 - 15:30 @ 東京</td>
+        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27776"  style="color:#fff;">申し込む</a></td>
       </tr>
     </tbody>
   </table>
@@ -159,8 +159,8 @@ yes
     </thead>
     <tbody>
       <tr class="available"><!-- available,full,finish-->
-        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27777"  style="color:#fff;">申し込む</a></td>
         <td>2015/07/20（月） 16:00 - 18:00 @ 東京</td>
+        <td class="state"><a href="https://coedo-rails.doorkeeper.jp/events/27777"  style="color:#fff;">申し込む</a></td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
Railsguidesのデフォルトのテーブルでは、480px 以下の時にテーブルの表示がおかしいので、特設のページのテーブルだけ修正を行います。

- [x] セミナー情報のテーブルの崩れを修正
- [x] 電子書籍の内容のテーブルの崩れを修正
- [x] ボタンの横幅の修正