### PR TITLE
`/'へのリンクを index.html に変換した。ヘッダを削除するようにした

### DIFF
--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -1,5 +1,6 @@
 require 'redcarpet'
 require 'coderay'
+require 'nokogiri'
 require "cgi"
 
 module Dash
@@ -55,7 +56,13 @@ module Dash
     end
     # relative
     html_body.gsub!('src="/images/', 'src="./images/')
+    html_body.gsub!('href="/"', 'src="./index.html"')
     html_body
+    # Rremove Navigation and Header
+    doc = Nokogiri::HTML.parse(html_body, nil, 'utf-8')
+    doc.search("#topNav").remove
+    doc.search("#header").remove
+    html_body = doc.to_html
   end
 
   def copy_assets(source_dir, destination_dir)


### PR DESCRIPTION
1. `/` へのリンクがエラーとなっていたので、 index.html へと書きかえるようにしました。
2. ナビゲーションとヘッダを削除するようにしました。

フッターにはドキュメントの目次があったので一覧できた方が良いかと思い残しました。