### PR TITLE
誤訳修正

### DIFF
--- a/guides/archive/ja/active_record_querying.md
+++ b/guides/archive/ja/active_record_querying.md
@@ -164,7 +164,7 @@ client = Client.take(2)
 SELECT * FROM clients LIMIT 2
 ```
 
-`take`メソッドの動作は、`find`メソッドとまったく同じです。ただし、`find`メソッドでは、マッチするレコードが見つからない場合に`ActiveRecord::RecordNotFound`例外が発生する点だけが異なります。
+`take!`メソッドの動作は、`take`メソッドとまったく同じです。ただし、`take!`メソッドでは、マッチするレコードが見つからない場合に`ActiveRecord::RecordNotFound`例外が発生する点だけが異なります。
 
 TIP: このメソッドで取り出されるレコードは、使用するデータベースエンジンによっても異なることがあります。
 


### PR DESCRIPTION
英文該当箇所

> The take! method behaves exactly like take, except that it will raise ActiveRecord::RecordNotFound if no matching record is found.

そもそもtakeとfindは別物なので、おかしいと思いました。修正いたします。