### PR TITLE
Fix link to rubygems guide

### DIFF
--- a/guides/source/ja/getting_started.md
+++ b/guides/source/ja/getting_started.md
@@ -19,7 +19,7 @@ Rails をはじめよう
 本ガイドは、ゼロからRailsアプリケーションを構築したいと考えている初心者を対象にしています。読者がRailsの経験がないことを前提としています。ただし、このドキュメントを最大限に活用するために、以下のソフトウェアがインストールされ、利用可能な状態になっていることを前提としています。
 
 * [Ruby](https://www.ruby-lang.org/ja/downloads/) 2.2.2以降。
-* [RubyGems](http://rubygems.org)パッケージングシステム。これはRuby 1.9以降であればRubyをインストールすると自動的に導入されます。RubyGemsの詳細については、[RubyGemsガイド](http://rubygems-guides-jp.herokuapp.com/)を参照してください。
+* [RubyGems](http://rubygems.org)パッケージングシステム。これはRuby 1.9以降であればRubyをインストールすると自動的に導入されます。RubyGemsの詳細については、[RubyGemsガイド](http://guides.rubygems.org/)を参照してください。
 * [SQLite3データベース](http://www.sqlite.org)がインストールされ、正常に動作する状態になっていること。
 
 Railsとは、Rubyプログラミング言語の上で動作するWebアプリケーションフレームワークです。


### PR DESCRIPTION
RubyGemsガイドのリンク先が↓のようになっていたので、翻訳元の指してるリンク先に入れ替えました 😃 

![image](https://cloud.githubusercontent.com/assets/82371/22731927/c3232a84-ee2f-11e6-8c05-64d928647d08.png)
