### PR TITLE
"lazy" はこの文脈で「遅延」ではないので「ずぼら」に

### DIFF
--- a/guides/source/ja/i18n.md
+++ b/guides/source/ja/i18n.md
@@ -570,7 +570,7 @@ I18n.t 'activerecord.errors.messages'
 # => {:inclusion=>"is not included in the list", :exclusion=> ... }
 ```
 
-#### 遅延参照(lazy lookup)
+#### "ずぼら" 参照("lazy" lookup)
 
 Railsには、 _ビュー_ 内部でロケールを参照するための便利な方法が実装されています。以下のような辞書があるとします。
 


### PR DESCRIPTION
「ずぼら」が最適かどうか議論の余地がありますが、少なくとも「遅延」は誤訳と思われるので書き換えたいです。