### PR TITLE
Revert changing to ApplicationRecord

### DIFF
--- a/guides/source/ja/active_record_basics.md
+++ b/guides/source/ja/active_record_basics.md
@@ -83,7 +83,7 @@ Active Recordのモデルを作成する
 Active Recordモデルの作成は非常に簡単です。以下のように`ApplicationRecord`クラスのサブクラスを作成するだけで完了します。
 
 ```ruby
-class Product < ApplicationRecord 
+class Product < ApplicationRecord
 end
 ```
 
@@ -110,10 +110,10 @@ puts p.name # "Some Book"
 
 Railsアプリケーションで別の命名ルールを使用しなければならない、レガシデータベースを使用してRailsアプリケーションを作成しないといけないなどの場合にはどうすればよいでしょうか。そんなときにはデフォルトの命名ルールを簡単にオーバーライドできます。
 
-`ApplicationRecord.table_name=`メソッドを使用して、使用すべきテーブル名を明示的に指定できます。
+`ActiveRecord::Base.table_name=`メソッドを使用して、使用すべきテーブル名を明示的に指定できます。
 
 ```ruby
-class Product < ApplicationRecord 
+class Product < ApplicationRecord
   self.table_name = "PRODUCT"
 end
 ```
@@ -128,10 +128,10 @@ class FunnyJoke < ActiveSupport::TestCase
 end
 ```
 
-`ApplicationRecord.primary_key=`メソッドを使用して、テーブルの主キーとして使用されるカラム名もオーバーライドできます。
+`ActiveRecord::Base.primary_key=`メソッドを使用して、テーブルの主キーとして使用されるカラム名もオーバーライドできます。
 
 ```ruby
-class Product < ApplicationRecord 
+class Product < ApplicationRecord
   self.primary_key = "product_id"
 end
 ```
@@ -237,7 +237,7 @@ Active Recordを使用して、モデルがデータベースに書き込まれ�
 以下の例で簡単に説明します。
 
 ```ruby
-class User < ApplicationRecord 
+class User < ApplicationRecord
   validates :name, presence: true
 end
 


### PR DESCRIPTION
https://github.com/yasslab/railsguides.jp/commit/9792c05c2f8164ccfd2a539e4916dca2e8eb65b8 のコミットで修正されている箇所はそのまま ActiveRecord::Base が正しいようです。

[Active Record Basics — Ruby on Rails Guides](http://guides.rubyonrails.org/active_record_basics.html#overriding-the-naming-conventions)

git revert でコミット作ろうかと思いましたが、もともとのコミットには`guides/archive.zip` の差分もあるので手動で `ActiveRecord::Base` に戻しました