### PR TITLE
`errors.add`のコード例を修正

### DIFF
--- a/guides/source/ja/active_record_validations.md
+++ b/guides/source/ja/active_record_validations.md
@@ -170,7 +170,7 @@ end
 >> Person.create.errors[:name].any? # => true
 ```
 
-より高度なレベルでのバリデーションエラーについては、[バリデーションエラーの取り扱い](#バリデーションエラーに対応する)セクションを参照してください。 ### `errors.details` 無効(invalid)な属性において、どのバリデーションが失敗したのか調べるために`errors.details[:attribute]`が利用できます。これは`:error`がキーで、失敗したバリデーターのシンボルが値となるハッシュの配列を返します。 ```ruby class Person < ApplicationRecord validates :name, presence: true end >> person = Person.new >> person.valid? >> person.errors.details[:name] # => [{error: :blank}] ``` 
+より高度なレベルでのバリデーションエラーについては、[バリデーションエラーの取り扱い](#バリデーションエラーに対応する)セクションを参照してください。 ### `errors.details` 無効(invalid)な属性において、どのバリデーションが失敗したのか調べるために`errors.details[:attribute]`が利用できます。これは`:error`がキーで、失敗したバリデーターのシンボルが値となるハッシュの配列を返します。 ```ruby class Person < ApplicationRecord validates :name, presence: true end >> person = Person.new >> person.valid? >> person.errors.details[:name] # => [{error: :blank}] ```
 
 バリデーションヘルパー
 ------------------
@@ -526,7 +526,7 @@ class GoodnessValidator
 
   def validate
     if some_complex_condition_involving_ivars_and_private_methods?
-      @person.errors[:base] << "これは悪人だ" 
+      @person.errors[:base] << "これは悪人だ"
     end
   end
 
@@ -704,7 +704,7 @@ end
 class MyValidator < ActiveModel::Validator
   def validate(record)
     unless record.name.starts_with? 'X'
-      record.errors[:name] << '名前はXで始まる必要があります' 
+      record.errors[:name] << '名前はXで始まる必要があります'
     end
   end
 end
@@ -826,35 +826,35 @@ person.errors[:name]
 ```ruby
 class Person < ActiveRecord::Base
   def a_method_used_for_validation_purposes
-    errors.add(:name, "以下の文字を含むことはできません !@#%*()_-+=")
+    errors.add(:name, "は以下の文字を含むことはできません !@#%*()_-+=")
   end
 end
 
 person = Person.create(name: "!@#")
 
 person.errors[:name]
-# => ["以下の文字を含むことはできません !@#%*()_-+="]
+# => ["は以下の文字を含むことはできません !@#%*()_-+="]
 
 person.errors.full_messages
-# => ["Name cannot contain the characters !@#%*()_-+="]
+# => ["Name は以下の文字を含むことはできません !@#%*()_-+="]]
 ```
 
 `[]=`セッターを使用して同じことを行えます。
 
 ```ruby
 class Person < ActiveRecord::Base
-    def a_method_used_for_validation_purposes
-      errors[:name] = "以下の文字を含むことはできません !@#%*()_-+="
-    end
+  def a_method_used_for_validation_purposes
+    errors[:name] = "は以下の文字を含むことはできません !@#%*()_-+="
   end
+end
 
-  person = Person.create(name: "!@#")
+person = Person.create(name: "!@#")
 
-  person.errors[:name]
-   # => ["以下の文字を含むことはできません !@#%*()_-+="]
+person.errors[:name]
+# => ["は以下の文字を含むことはできません !@#%*()_-+="]
 
-  person.errors.to_a
-   # => ["Nameは以下の文字を含むことはできません !@#%*()_-+="]
+person.errors.to_a
+# => ["Name は以下の文字を含むことはできません !@#%*()_-+="]]
 ```
 
 ### `errors[:base]`


### PR DESCRIPTION
- インデントの間違いを修正
- 訳されてない箇所を訳した
- 「は」が入っている箇所と入っていない箇所があり統一されていなかったので、「は」を入れる形に統一した