### PR TITLE
railsguides.jp向けのカスタマイズ部分を外部ファイルに切り分け (generator.rb)

### DIFF
--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -59,5 +59,5 @@ ERROR
 end
 
 require 'rails_guides/markdown'
-require "rails_guides/generator"
-RailsGuides::Generator.new.generate
+require "rails_guides/generator_ja"
+RailsGuides::GeneratorJa.new.generate

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -211,10 +211,6 @@ module RailsGuides
       end
     end
 
-    def references?(guide)
-      yml[guide.sub(".md", "")]
-    end
-
     def references_md(guide)
       md = <<-MD
 

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -97,7 +97,6 @@ module RailsGuides
       generate_guides
       copy_assets
       generate_mobi if kindle?
-      generate_docset if dash?
     end
 
     private

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -84,7 +84,6 @@ module RailsGuides
       @warnings = ENV['WARNINGS'] == '1'
       @all      = ENV['ALL']      == '1'
       @kindle   = ENV['KINDLE']   == '1'
-      @dash     = ENV['DASH']     == '1'
       @version  = ENV['RAILS_VERSION'] || 'local'
       @lang     = ENV['GUIDES_LANGUAGE']
     end

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -211,20 +211,6 @@ module RailsGuides
       end
     end
 
-    def references_md(guide)
-      md = <<-MD
-
-
-参考資料
----------
-
-references#{"-" * 80}
-      MD
-      yml[guide.sub(".md", "")].each_with_object(md) do |link, str|
-        str << "* [#{link['title']}](#{link['url']})\n"
-      end
-    end
-
     def warn_about_broken_links(html)
       anchors = extract_anchors(html)
       check_fragment_identifiers(html, anchors)

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -211,10 +211,6 @@ module RailsGuides
       end
     end
 
-    def yml
-      @yml ||= YAML.load(File.read(File.join(source_dir, "references.yml")))
-    end
-
     def references?(guide)
       yml[guide.sub(".md", "")]
     end

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -106,10 +106,6 @@ module RailsGuides
       @kindle
     end
 
-    def dash?
-      @dash
-    end
-
     def check_for_kindlegen
       if `which kindlegen`.blank?
         raise "Can't create a kindle version without `kindlegen`."

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -129,8 +129,6 @@ module RailsGuides
         output
       elsif kindle?
         "#@guides_dir/output/kindle/#@lang"
-      elsif dash?
-        "#@guides_dir/output/dash/#@lang"
       else
         "#@guides_dir/output/#@lang"
       end.sub(%r</$>, '')

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -118,15 +118,6 @@ module RailsGuides
       puts "(kindlegen log at #{out})."
     end
 
-    def generate_docset
-      require 'rails_guides/dash'
-      out = "#{output_dir}/docset.out"
-      Dash.generate @source_dir, output_dir,
-        "ruby_on_rails_guides_#@version%s.docset" % (@lang.present? ? ".#@lang" : ''),
-        out
-      puts "(docset generate log at #{out})."
-    end
-
     def mobi
       "ruby_on_rails_guides_#@version%s.mobi" % (@lang.present? ? ".#@lang" : '')
     end

--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -193,7 +193,7 @@ module RailsGuides
       layout = kindle? ? 'kindle/layout' : 'layout'
 
       File.open(output_path, 'w') do |f|
-        view = ActionView::Base.new(source_dir, :edge => @edge, :version => @version, :mobi => "kindle/#{mobi}", :lang => @lang)
+        view = ActionView::Base.new(source_dir, :edge => @edge, :version => @version, :mobi => "kindle/#{mobi}")
         view.extend(Helpers)
 
         if guide =~ /\.(\w+)\.erb$/
@@ -202,7 +202,6 @@ module RailsGuides
           result = view.render(:layout => layout, :formats => [$1], :file => $`)
         else
           body = File.read(File.join(source_dir, guide))
-          body = body << references_md(guide) if references?(guide)
           result = RailsGuides::Markdown.new(view, layout).render(body)
 
           warn_about_broken_links(result) if @warnings

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -17,5 +17,14 @@ module RailsGuides
     def dash?
       @dash
     end
+
+    def generate_docset
+      require 'rails_guides/dash'
+      out = "#{output_dir}/docset.out"
+      Dash.generate @source_dir, output_dir,
+                    "ruby_on_rails_guides_#@version%s.docset" % (@lang.present? ? ".#@lang" : ''),
+                    out
+      puts "(docset generate log at #{out})."
+    end
   end
 end

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -28,17 +28,8 @@ module RailsGuides
     end
 
     def initialize_dirs(output)
-      @guides_dir = File.join(File.dirname(__FILE__), '..')
-      @source_dir = "#@guides_dir/source/#@lang"
-      @output_dir = if output
-        output
-      elsif kindle?
-        "#@guides_dir/output/kindle/#@lang"
-      elsif dash?
-        "#@guides_dir/output/dash/#@lang"
-      else
-        "#@guides_dir/output/#@lang"
-      end.sub(%r</$>, '')
+      super
+      @output_dir = "#@guides_dir/output/dash/#@lang".sub(%r</$>, '') if dash?
     end
 
     def generate_guide(guide, output_file)

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -65,5 +65,9 @@ module RailsGuides
         f.write(result)
       end
     end
+
+    def yml
+      @yml ||= YAML.load(File.read(File.join(source_dir, "references.yml")))
+    end
   end
 end

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -73,5 +73,19 @@ module RailsGuides
     def references?(guide)
       yml[guide.sub(".md", "")]
     end
+
+    def references_md(guide)
+      md = <<-MD
+
+
+参考資料
+---------
+
+references#{"-" * 80}
+      MD
+      yml[guide.sub(".md", "")].each_with_object(md) do |link, str|
+        str << "* [#{link['title']}](#{link['url']})\n"
+      end
+    end
   end
 end

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -40,5 +40,30 @@ module RailsGuides
         "#@guides_dir/output/#@lang"
       end.sub(%r</$>, '')
     end
+
+    def generate_guide(guide, output_file)
+      output_path = output_path_for(output_file)
+      puts "Generating #{guide} as #{output_file}"
+      layout = kindle? ? 'kindle/layout' : 'layout'
+
+      File.open(output_path, 'w') do |f|
+        view = ActionView::Base.new(source_dir, :edge => @edge, :version => @version, :mobi => "kindle/#{mobi}", :lang => @lang)
+        view.extend(Helpers)
+
+        if guide =~ /\.(\w+)\.erb$/
+          # Generate the special pages like the home.
+          # Passing a template handler in the template name is deprecated. So pass the file name without the extension.
+          result = view.render(:layout => layout, :formats => [$1], :file => $`)
+        else
+          body = File.read(File.join(source_dir, guide))
+          body = body << references_md(guide) if references?(guide)
+          result = RailsGuides::Markdown.new(view, layout).render(body)
+
+          warn_about_broken_links(result) if @warnings
+        end
+
+        f.write(result)
+      end
+    end
   end
 end

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -1,0 +1,6 @@
+require_relative "generator"
+
+module RailsGuides
+  class GeneratorJa < Generator
+  end
+end

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -7,6 +7,11 @@ module RailsGuides
       @dash = ENV['DASH'] == '1'
     end
 
+    def generate
+      super
+      generate_docset if dash?
+    end
+
     private
 
     def dash?

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -69,5 +69,9 @@ module RailsGuides
     def yml
       @yml ||= YAML.load(File.read(File.join(source_dir, "references.yml")))
     end
+
+    def references?(guide)
+      yml[guide.sub(".md", "")]
+    end
   end
 end

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -58,7 +58,7 @@ module RailsGuides
     end
 
     def yml
-      @yml ||= YAML.load(File.read(File.join(source_dir, "references.yml")))
+      @yml ||= YAML.load_file(File.join(source_dir, "references.yml"))
     end
 
     def references?(guide)

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -2,5 +2,9 @@ require_relative "generator"
 
 module RailsGuides
   class GeneratorJa < Generator
+    def set_flags_from_environment
+      super
+      @dash = ENV['DASH'] == '1'
+    end
   end
 end

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -26,5 +26,19 @@ module RailsGuides
                     out
       puts "(docset generate log at #{out})."
     end
+
+    def initialize_dirs(output)
+      @guides_dir = File.join(File.dirname(__FILE__), '..')
+      @source_dir = "#@guides_dir/source/#@lang"
+      @output_dir = if output
+        output
+      elsif kindle?
+        "#@guides_dir/output/kindle/#@lang"
+      elsif dash?
+        "#@guides_dir/output/dash/#@lang"
+      else
+        "#@guides_dir/output/#@lang"
+      end.sub(%r</$>, '')
+    end
   end
 end

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -6,5 +6,11 @@ module RailsGuides
       super
       @dash = ENV['DASH'] == '1'
     end
+
+    private
+
+    def dash?
+      @dash
+    end
   end
 end


### PR DESCRIPTION
rails/railsのmasterを取り込む際に、元のファイルに対してカスタマイズが行われているとマージ時にコンフリクトが発生してしまうので、カスタマイズ部分を外部ファイルとして切り分けました。