### PR TITLE
railsguides.jp向けのカスタマイズ部分を外部ファイルに切り分け (heplers.rb)

### DIFF
--- a/guides/rails_guides/generator.rb
+++ b/guides/rails_guides/generator.rb
@@ -58,7 +58,7 @@ require 'action_controller'
 require 'action_view'
 
 require 'rails_guides/indexer'
-require 'rails_guides/helpers'
+require 'rails_guides/helpers_ja'
 require 'rails_guides/levenshtein'
 
 module RailsGuides
@@ -211,7 +211,7 @@ module RailsGuides
 
       File.open(output_path, 'w') do |f|
         view = ActionView::Base.new(source_dir, :edge => @edge, :version => @version, :mobi => "kindle/#{mobi}", :lang => @lang)
-        view.extend(Helpers)
+        view.extend(HelpersJa)
 
         if guide =~ /\.(\w+)\.erb$/
           # Generate the special pages like the home.

--- a/guides/rails_guides/helpers.rb
+++ b/guides/rails_guides/helpers.rb
@@ -36,19 +36,6 @@ module RailsGuides
       end
     end
 
-    def docs_for_sitemap(position)
-      case position
-      when 'L'
-        documents_by_section.to(3)
-      when 'C'
-        documents_by_section.from(4).take(2)
-      when 'R'
-        documents_by_section.from(6)
-      else
-        raise "Unknown position: #{position}"
-      end
-    end
-
     def author(name, nick, image = 'credits_pic_blank.gif', &block)
       image = "images/#{image}"
 

--- a/guides/rails_guides/helpers.rb
+++ b/guides/rails_guides/helpers.rb
@@ -15,7 +15,7 @@ module RailsGuides
     end
 
     def documents_by_section
-      @documents_by_section ||= YAML.load_file(File.expand_path("../../source/#@lang/documents.yaml", __FILE__))
+      @documents_by_section ||= YAML.load_file(File.expand_path('../../source/documents.yaml', __FILE__))
     end
 
     def documents_flat

--- a/guides/rails_guides/helpers.rb
+++ b/guides/rails_guides/helpers.rb
@@ -23,9 +23,7 @@ module RailsGuides
     end
 
     def finished_documents(documents)
-      # Enable this line when not like to display WIP documents
-      #documents.reject { |document| document['work_in_progress'] }
-      documents
+      documents.reject { |document| document['work_in_progress'] }
     end
 
     def docs_for_menu(position=nil)

--- a/guides/rails_guides/helpers_ja.rb
+++ b/guides/rails_guides/helpers_ja.rb
@@ -1,0 +1,7 @@
+require_relative 'helpers'
+
+module RailsGuides
+  module HelpersJa
+    include Helpers
+  end
+end

--- a/guides/rails_guides/helpers_ja.rb
+++ b/guides/rails_guides/helpers_ja.rb
@@ -13,5 +13,18 @@ module RailsGuides
       #documents.reject { |document| document['work_in_progress'] }
       documents
     end
+
+    def docs_for_sitemap(position)
+      case position
+        when 'L'
+          documents_by_section.to(3)
+        when 'C'
+          documents_by_section.from(4).take(2)
+        when 'R'
+          documents_by_section.from(6)
+        else
+          raise "Unknown position: #{position}"
+      end
+    end
   end
 end

--- a/guides/rails_guides/helpers_ja.rb
+++ b/guides/rails_guides/helpers_ja.rb
@@ -7,5 +7,11 @@ module RailsGuides
     def documents_by_section
       @documents_by_section ||= YAML.load_file(File.expand_path("../../source/#@lang/documents.yaml", __FILE__))
     end
+
+    def finished_documents(documents)
+      # Enable this line when not like to display WIP documents
+      #documents.reject { |document| document['work_in_progress'] }
+      documents
+    end
   end
 end

--- a/guides/rails_guides/helpers_ja.rb
+++ b/guides/rails_guides/helpers_ja.rb
@@ -3,5 +3,9 @@ require_relative 'helpers'
 module RailsGuides
   module HelpersJa
     include Helpers
+
+    def documents_by_section
+      @documents_by_section ||= YAML.load_file(File.expand_path("../../source/#@lang/documents.yaml", __FILE__))
+    end
   end
 end


### PR DESCRIPTION
#318 と同様に `helpers.rb` もオリジナルに入っていた変更を外部ファイルに切り出しました