### PR TITLE
docset生成をdocset gemに任せるようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,9 @@ gem 'actionpack'
 gem 'nokogiri'
 gem 'redcarpet'
 
+# Generate docset
+gem 'docset'
+
 # Monitoring tools
 gem 'newrelic_rpm'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,8 @@ GEM
     colorator (1.1.0)
     colored (1.2)
     diff-lcs (1.2.5)
+    docset (0.1.0)
+      sqlite3 (~> 1.3)
     erubis (2.7.0)
     ethon (0.10.1)
       ffi (>= 1.3.0)
@@ -151,6 +153,7 @@ GEM
       rubyzip (~> 1.0)
       websocket (~> 1.0)
     slop (3.6.0)
+    sqlite3 (1.3.13)
     thor (0.19.4)
     thread_safe (0.3.5)
     turnip (2.1.1)
@@ -181,6 +184,7 @@ DEPENDENCIES
   activesupport
   bundler
   capybara
+  docset
   gtt-downloader
   html-proofer
   jekyll
@@ -205,4 +209,4 @@ RUBY VERSION
    ruby 2.4.0p0
 
 BUNDLED WITH
-   1.13.7
+   1.14.6

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -9,7 +9,6 @@ module Dash
 
   def generate(source_dir, output_dir, out_dir)
     puts "Output Dir: #{output_dir}"
-    @stylesheets = []
 
     docset_path = "#{output_dir}/#{out_dir}"
     FileUtils.rm_r(docset_path) if Dir.exists? docset_path
@@ -69,13 +68,6 @@ module Dash
       dst = "#{destination_dir}/#{dir}"
       FileUtils.rm_r dst if Dir.exists? dst
       FileUtils.cp_r src, dst
-
-      if dir == 'stylesheets'
-        Dir.glob("#{dst}/*").each do |stylesheet|
-          next if stylesheet =~ /kindle.css\z/
-          @stylesheets << File.basename(stylesheet)
-        end
-      end
     end
   end
 

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -11,7 +11,6 @@ module Dash
     puts "Output Dir: #{output_dir}"
     @debug = debug
     @stylesheets = []
-    html_body = ''
 
     docset_path = "#{output_dir}/#{out_dir}"
     FileUtils.rm_r(docset_path) if Dir.exists? docset_path
@@ -115,4 +114,3 @@ module Dash
     HTML
   end
 end
-

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -70,7 +70,8 @@ class Dash < Struct.new(:output_dir, :docset_filename)
   end
 
   def each_file_paths
-    Dir.glob("#{output_dir}/*.html").each do|file_path|
+    pattern = File.join(output_dir, '*.html')
+    Dir.glob(pattern).each do|file_path|
       next if file_path =~ /release_notes.html\z/
       next if File.basename(file_path) =~ /\A_/
       yield file_path

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -7,7 +7,7 @@ require "cgi"
 module Dash
   extend self
 
-  def generate(source_dir, output_dir, out_dir, logfile, debug: false)
+  def generate(source_dir, output_dir, out_dir, debug: false)
     puts "Output Dir: #{output_dir}"
     @debug = debug
     @stylesheets = []

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 require 'nokogiri'
 require 'cgi'
+require 'docset'
 
 class Dash < Struct.new(:output_dir, :docset_filename)
   class << self
@@ -104,21 +105,13 @@ class Dash < Struct.new(:output_dir, :docset_filename)
   end
 
   def build_info_plist
-    File.write("#{contents_dir}/Info.plist", <<-HTML)
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-  <dict>
-    <key>CFBundleIdentifier</key>
-    <string>railsguidesjp</string>
-    <key>CFBundleName</key>
-    <string>Railsガイド</string>
-    <key>DocSetPlatformFamily</key>
-    <string>rails</string>
-    <key>isDashDocset</key>
-    <true/>
-  </dict>
-</plist>
-    HTML
+    plist = Docset::Plist.new(
+      id: 'railsguidesjp',
+      name: 'Railsガイド',
+      family: 'rails',
+      js: false
+    )
+    file = "#{contents_dir}/Info.plist"
+    File.write(file, plist.to_s)
   end
 end

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -4,10 +4,10 @@ require 'coderay'
 require 'nokogiri'
 require "cgi"
 
-class Dash < Struct.new(:source_dir, :output_dir, :out_dir)
+class Dash < Struct.new(:source_dir, :output_dir, :docset_filename)
   class << self
-    def generate(source_dir, output_dir, out_dir)
-      new(source_dir, output_dir, out_dir).generate
+    def generate(source_dir, output_dir, docset_filename)
+      new(source_dir, output_dir, docset_filename).generate
     end
   end
 
@@ -46,7 +46,7 @@ class Dash < Struct.new(:source_dir, :output_dir, :out_dir)
   private
 
   def docset_path
-    File.join(output_dir, out_dir)
+    File.join(output_dir, docset_filename)
   end
 
   def create_html_and_register_index(file, doc_name)

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -11,6 +11,11 @@ class Dash < Struct.new(:source_dir, :output_dir, :out_dir)
     end
   end
 
+  def initialize(*)
+    super
+    self.output_dir = File.absolute_path(output_dir)
+  end
+
   def generate
     puts "Output Dir: #{output_dir}"
 
@@ -25,7 +30,6 @@ class Dash < Struct.new(:source_dir, :output_dir, :out_dir)
     initialize_sqlite
     copy_assets output_dir, @documents_dir
 
-    output_dir = File.absolute_path(self.output_dir)
     Dir.chdir output_dir do
       Dir.glob("#{output_dir}/*.html").each do|file_path|
         next if file_path =~ /release_notes.html\z/

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -83,9 +83,7 @@ module Dash
   end
 
   def build_info_plist
-    file = "#{@contents_dir}/Info.plist"
-    File.delete if File.exists? file
-    File.write(file, <<-HTML)
+    File.write("#{@contents_dir}/Info.plist", <<-HTML)
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -57,7 +57,7 @@ module Dash
     # relative
     html_body.gsub!('src="/images/', 'src="./images/')
     html_body.gsub!('href="/"', 'src="./index.html"')
-    html_body
+
     # Rremove Navigation and Header
     doc = Nokogiri::HTML.parse(html_body, nil, 'utf-8')
     doc.search("#topNav").remove

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -19,7 +19,6 @@ class Dash < Struct.new(:source_dir, :output_dir, :out_dir)
   def generate
     puts "Output Dir: #{output_dir}"
 
-    docset_path = "#{output_dir}/#{out_dir}"
     FileUtils.rm_r(docset_path) if Dir.exists? docset_path
     @contents_dir = "#{docset_path}/Contents"
     @resources_dir = "#{@contents_dir}/Resources"
@@ -45,6 +44,10 @@ class Dash < Struct.new(:source_dir, :output_dir, :out_dir)
   end
 
   private
+
+  def docset_path
+    File.join(output_dir, out_dir)
+  end
 
   def create_html_and_register_index(file, doc_name)
     html_body = file.read

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -29,10 +29,8 @@ class Dash < Struct.new(:output_dir, :docset_filename)
     each_file_paths do |file_path|
       doc_name = File.basename(file_path).sub(".md", "")
 
-      File.open(file_path) do |file|
-        html = create_html_and_register_index(file, doc_name)
-        File.write("#{documents_dir}/#{doc_name}", html)
-      end
+      html = create_html_and_register_index(file_path, doc_name)
+      File.write("#{documents_dir}/#{doc_name}", html)
     end
   end
 
@@ -62,8 +60,8 @@ class Dash < Struct.new(:output_dir, :docset_filename)
     File.join(output_dir, docset_filename)
   end
 
-  def create_html_and_register_index(file, doc_name)
-    html_body = file.read
+  def create_html_and_register_index(html_path, doc_name)
+    html_body = File.read(html_path)
     html_body.scan(/(<h[1-5]( [^>]+)?>(.*?)<\/h([1-5])>)/).each do |match|
       tag = match[0]
       name = ActionView::Base.full_sanitizer.sanitize(match[2])

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -25,10 +25,7 @@ class Dash < Struct.new(:output_dir, :docset_filename)
     copy_assets output_dir, documents_dir
 
     each_file_paths do |file_path|
-      doc_name = File.basename(file_path).sub(".md", "")
-
-      html = create_html_and_register_index(file_path, doc_name)
-      File.write("#{documents_dir}/#{doc_name}", html)
+      create_html_and_register_index(file_path)
     end
   end
 
@@ -58,7 +55,8 @@ class Dash < Struct.new(:output_dir, :docset_filename)
     File.join(output_dir, docset_filename)
   end
 
-  def create_html_and_register_index(html_path, doc_name)
+  def create_html_and_register_index(html_path)
+    doc_name = File.basename(html_path)
     html_body = File.read(html_path)
     html_body.scan(/(<h[1-5]( [^>]+)?>(.*?)<\/h([1-5])>)/).each do |match|
       tag = match[0]
@@ -81,7 +79,8 @@ class Dash < Struct.new(:output_dir, :docset_filename)
     doc = Nokogiri::HTML.parse(html_body, nil, 'utf-8')
     doc.search("#topNav").remove
     doc.search("#header").remove
-    doc.to_html
+
+    File.write("#{documents_dir}/#{doc_name}", doc.to_html)
   end
 
   def copy_assets(source_dir, destination_dir)

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -62,7 +62,7 @@ module Dash
     doc = Nokogiri::HTML.parse(html_body, nil, 'utf-8')
     doc.search("#topNav").remove
     doc.search("#header").remove
-    html_body = doc.to_html
+    doc.to_html
   end
 
   def copy_assets(source_dir, destination_dir)

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -26,14 +26,12 @@ class Dash < Struct.new(:output_dir, :docset_filename)
     initialize_sqlite
     copy_assets output_dir, documents_dir
 
-    Dir.chdir output_dir do
-      each_file_paths do |file_path|
-        doc_name = File.basename(file_path).sub(".md", "")
+    each_file_paths do |file_path|
+      doc_name = File.basename(file_path).sub(".md", "")
 
-        File.open(file_path) do |file|
-          html = create_html_and_register_index(file, doc_name)
-          File.write("#{documents_dir}/#{doc_name}", html)
-        end
+      File.open(file_path) do |file|
+        html = create_html_and_register_index(file, doc_name)
+        File.write("#{documents_dir}/#{doc_name}", html)
       end
     end
   end

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -4,10 +4,14 @@ require 'coderay'
 require 'nokogiri'
 require "cgi"
 
-module Dash
-  extend self
+class Dash < Struct.new(:source_dir, :output_dir, :out_dir)
+  class << self
+    def generate(source_dir, output_dir, out_dir)
+      new(source_dir, output_dir, out_dir).generate
+    end
+  end
 
-  def generate(source_dir, output_dir, out_dir)
+  def generate
     puts "Output Dir: #{output_dir}"
 
     docset_path = "#{output_dir}/#{out_dir}"
@@ -21,7 +25,7 @@ module Dash
     initialize_sqlite
     copy_assets output_dir, @documents_dir
 
-    output_dir = File.absolute_path(output_dir)
+    output_dir = File.absolute_path(self.output_dir)
     Dir.chdir output_dir do
       Dir.glob("#{output_dir}/*.html").each do|file_path|
         next if file_path =~ /release_notes.html\z/

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -77,7 +77,7 @@ class Dash < Struct.new(:output_dir, :docset_filename)
     html_body.gsub!('src="/images/', 'src="./images/')
     html_body.gsub!('href="/"', 'src="./index.html"')
 
-    # Rremove Navigation and Header
+    # Remove Navigation and Header
     doc = Nokogiri::HTML.parse(html_body, nil, 'utf-8')
     doc.search("#topNav").remove
     doc.search("#header").remove

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-require 'redcarpet'
-require 'coderay'
 require 'nokogiri'
-require "cgi"
+require 'cgi'
 
 class Dash < Struct.new(:output_dir, :docset_filename)
   class << self

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -27,9 +27,7 @@ class Dash < Struct.new(:output_dir, :docset_filename)
     copy_assets output_dir, documents_dir
 
     Dir.chdir output_dir do
-      Dir.glob("#{output_dir}/*.html").each do|file_path|
-        next if file_path =~ /release_notes.html\z/
-        next if File.basename(file_path) =~ /\A_/
+      each_file_paths do |file_path|
         doc_name = File.basename(file_path).sub(".md", "")
 
         File.open(file_path) do |file|
@@ -41,6 +39,14 @@ class Dash < Struct.new(:output_dir, :docset_filename)
   end
 
   private
+
+  def each_file_paths
+    Dir.glob("#{output_dir}/*.html").each do|file_path|
+      next if file_path =~ /release_notes.html\z/
+      next if File.basename(file_path) =~ /\A_/
+      yield file_path
+    end
+  end
 
   def contents_dir
     File.join(docset_path, 'Contents')

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -39,7 +39,6 @@ module Dash
   end
 
   def create_html_and_register_index(file, doc_name)
-    title = ''
     html_body = file.read
     html_body.scan(/(<h[1-5]( [^>]+)?>(.*?)<\/h([1-5])>)/).each do |match|
       tag = match[0]
@@ -51,7 +50,7 @@ module Dash
       html_body.sub!(tag, %{<a name="#{hash}"></a>#{tag}})
 
       # Add Search Index
-      title = index_name = CGI.unescapeHTML(name).gsub("'"){ "''" }
+      index_name = CGI.unescapeHTML(name).gsub("'"){ "''" }
       sqlite %{INSERT OR IGNORE INTO searchIndex(name, type, path) VALUES ('#{index_name}', 'Guide', '#{doc_name}##{hash}');}
     end
     # relative

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -44,6 +44,8 @@ class Dash < Struct.new(:source_dir, :output_dir, :out_dir)
     end
   end
 
+  private
+
   def create_html_and_register_index(file, doc_name)
     html_body = file.read
     html_body.scan(/(<h[1-5]( [^>]+)?>(.*?)<\/h([1-5])>)/).each do |match|

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -7,9 +7,8 @@ require "cgi"
 module Dash
   extend self
 
-  def generate(source_dir, output_dir, out_dir, debug: false)
+  def generate(source_dir, output_dir, out_dir)
     puts "Output Dir: #{output_dir}"
-    @debug = debug
     @stylesheets = []
 
     docset_path = "#{output_dir}/#{out_dir}"
@@ -88,7 +87,6 @@ module Dash
   end
 
   def sqlite(query)
-    puts "[SQLite] #{query}" if @debug
     `sqlite3  #{@sqlite_db} "#{query}"`
   end
 

--- a/guides/rails_guides/dash.rb
+++ b/guides/rails_guides/dash.rb
@@ -4,10 +4,10 @@ require 'coderay'
 require 'nokogiri'
 require "cgi"
 
-class Dash < Struct.new(:source_dir, :output_dir, :docset_filename)
+class Dash < Struct.new(:output_dir, :docset_filename)
   class << self
-    def generate(source_dir, output_dir, docset_filename)
-      new(source_dir, output_dir, docset_filename).generate
+    def generate(output_dir, docset_filename)
+      new(output_dir, docset_filename).generate
     end
   end
 

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -21,11 +21,8 @@ module RailsGuides
 
     def generate_docset
       require 'rails_guides/dash'
-      out = "#{output_dir}/docset.out"
       Dash.generate @source_dir, output_dir,
-                    "ruby_on_rails_guides_#@version%s.docset" % (@lang.present? ? ".#@lang" : ''),
-                    out
-      puts "(docset generate log at #{out})."
+                    "ruby_on_rails_guides_#@version%s.docset" % (@lang.present? ? ".#@lang" : '')
     end
 
     def initialize_dirs(output)

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -21,8 +21,8 @@ module RailsGuides
 
     def generate_docset
       require 'rails_guides/dash'
-      Dash.generate @source_dir, output_dir,
-                    "ruby_on_rails_guides_#@version%s.docset" % (@lang.present? ? ".#@lang" : '')
+      docset_name = "ruby_on_rails_guides_#@version%s.docset" % (@lang.present? ? ".#@lang" : '')
+      Dash.generate(output_dir, docset_name)
     end
 
     def initialize_dirs(output)


### PR DESCRIPTION
docset生成を https://github.com/yasslab/docset を使うように書き換えました。

今はMacのDocsetのBundle作成のため以下のような処理をrailsguides.jp内で行っています。

- Bundle用のディレクトリ構造の作成
- Docset用のInfo.plist作成
- DocsetのDBの作成
- インデックスを追加するSQLの発行

コンテンツをdocsetに追加・編集する処理だけに集中できるよう、docset gemにこれらの処理を委譲しました。