### PR TITLE
docset gem を production 環境で使用しないように変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,6 @@ gem 'actionpack'
 gem 'nokogiri'
 gem 'redcarpet'
 
-# Generate docset
-gem 'docset'
-
 # Monitoring tools
 gem 'newrelic_rpm'
 
@@ -32,6 +29,8 @@ gem 'rack-contrib', '~> 1.4'
 gem 'html-proofer'
 
 group :development do
+  # Generate docset
+  gem 'docset'
   gem 'gtt-downloader'
 end
 


### PR DESCRIPTION
`docset` gem を production 環境で使用しようとした際に、依存している `sqlite3` が heroku の production 環境で利用出来ないため CI が落ちる現象が起きていました。

そのため、`docset` gem を production 環境で利用しないように development group に分けました。