### PR TITLE
.travis.yml の項目から before_deploy を削除

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,4 @@ deploy:
     secure: JHaaojmt64klUFQElkjE0arLV02cumMH0oDinvdRnnbMGCQVNJwTq8jlv9o1n9DctUDk+BvYJCU6B0cZHvqDlWgkZOR8VvXlaO644AmGKkCLEW1/6FCjEAitLkiRZ04kkGgVpDq5spcPDmjhSznYlUdonVgXq55M3IV3Yt+9GmU=
   on:
     branch: master
-  before_deploy: "echo 'ready?'"
   app: railsguides-jp


### PR DESCRIPTION
[Running commands before and after deploy](https://docs.travis-ci.com/user/deployment/heroku/#Running-commands-before-and-after-deploy) によると、`before_deploy` では デプロイ前に特定のコマンドを実行出来るようなのですが、 現在設定されているコマンドは特に必要が無いと思われるので削除しました。