### PR TITLE
errors.details 項目のレイアウト崩れを修正

### DIFF
--- a/guides/source/ja/active_record_validations.md
+++ b/guides/source/ja/active_record_validations.md
@@ -170,7 +170,21 @@ end
 >> Person.create.errors[:name].any? # => true
 ```
 
-より高度なレベルでのバリデーションエラーについては、[バリデーションエラーの取り扱い](#バリデーションエラーに対応する)セクションを参照してください。 ### `errors.details` 無効(invalid)な属性において、どのバリデーションが失敗したのか調べるために`errors.details[:attribute]`が利用できます。これは`:error`がキーで、失敗したバリデーターのシンボルが値となるハッシュの配列を返します。 ```ruby class Person < ApplicationRecord validates :name, presence: true end >> person = Person.new >> person.valid? >> person.errors.details[:name] # => [{error: :blank}] ``` 
+より高度なレベルでのバリデーションエラーについては、[バリデーションエラーの取り扱い](#バリデーションエラーに対応する)セクションを参照してください。
+
+### `errors.details`
+
+無効(invalid)な属性において、どのバリデーションが失敗したのか調べるために`errors.details[:attribute]`が利用できます。これは`:error`がキーで、失敗したバリデーターのシンボルが値となるハッシュの配列を返します。
+
+```ruby
+class Person < ApplicationRecord
+  validates :name, presence: true
+end
+>> person = Person.new
+>> person.valid?
+>> person.errors.details[:name]
+# => [{error: :blank}]
+```
 
 バリデーションヘルパー
 ------------------
@@ -526,7 +540,7 @@ class GoodnessValidator
 
   def validate
     if some_complex_condition_involving_ivars_and_private_methods?
-      @person.errors[:base] << "これは悪人だ" 
+      @person.errors[:base] << "これは悪人だ"
     end
   end
 
@@ -704,7 +718,7 @@ end
 class MyValidator < ActiveModel::Validator
   def validate(record)
     unless record.name.starts_with? 'X'
-      record.errors[:name] << '名前はXで始まる必要があります' 
+      record.errors[:name] << '名前はXで始まる必要があります'
     end
   end
 end


### PR DESCRIPTION
active_record_validations.html の `errors.details` 項目が以下のように崩れていたので、修正しました。

修正前：
[![https://gyazo.com/cad9e24eab11156f35fbaf7f8f7e75af](https://i.gyazo.com/cad9e24eab11156f35fbaf7f8f7e75af.png)](https://gyazo.com/cad9e24eab11156f35fbaf7f8f7e75af)

修正後：
[![https://gyazo.com/3f12428f2096ed1316a257a8d4f92da6](https://i.gyazo.com/3f12428f2096ed1316a257a8d4f92da6.png)](https://gyazo.com/3f12428f2096ed1316a257a8d4f92da6)