### PR TITLE
ヘッダーの閉じタグのサイズを修正

### DIFF
--- a/guides/source/ja/index.html.erb
+++ b/guides/source/ja/index.html.erb
@@ -53,7 +53,7 @@ Ruby on Rails ガイド：体系的に Rails を学ぼう
 </div>
 <% end %>
 <div class="announce">
-  <h6><a href="https://rebuild.fm/100/">Rebuild.fm Episode #100</a> でRailsガイドを紹介して頂きました :)</h4>
+  <h6><a href="https://rebuild.fm/100/">Rebuild.fm Episode #100</a> でRailsガイドを紹介して頂きました :)</h6>
 </div>
 
 <dl>


### PR DESCRIPTION
見出しの開始タグと終了タグのサイズが一致していなかったので修正しました。