### PR TITLE
コードブロック内のコメント部分とコード部分を分ける

### DIFF
--- a/guides/source/ja/active_job_basics.md
+++ b/guides/source/ja/active_job_basics.md
@@ -67,15 +67,24 @@ end
 キューへのジョブ登録は以下のように行います。
 
 ```ruby
-# 「キューイングシステムが空いたらジョブを実行する」とキューに登録する GuestsCleanupJob.perform_later guest
+# 「キューイングシステムが空いたらジョブを実行する」とキューに登録する
+GuestsCleanupJob.perform_later guest
 ```
 
 ```ruby
-# 明日正午に実行したいジョブをキューに登録する GuestsCleanupJob.set(wait_until: Date.tomorrow.noon).perform_later(guest) 
+# 明日正午に実行したいジョブをキューに登録する
+GuestsCleanupJob.set(wait_until: Date.tomorrow.noon).perform_later(guest) 
 ```
 
 ```ruby
-# 一週間後に実行したいジョブをキューに登録する GuestsCleanupJob.set(wait: 1.week).perform_later(guest) ``` ```ruby # `perform_now`と`perform_later`は`perform`を呼び出すので、 # 定義した引数を渡すことができる GuestsCleanupJob.perform_later(guest1, guest2, filter: 'some_filter')
+# 一週間後に実行したいジョブをキューに登録する
+GuestsCleanupJob.set(wait: 1.week).perform_later(guest)
+```
+
+```ruby
+# `perform_now`と`perform_later`は`perform`を呼び出すので、
+# 定義した引数を渡すことができる
+GuestsCleanupJob.perform_later(guest1, guest2, filter: 'some_filter')
 ```
 
 以上で終わりです。


### PR DESCRIPTION
コードブロック内部の記述で、コメント部分とコード部分が一緒になっており表示がおかしくなっていたので修正しました。

修正前

<img width="681" alt="before" src="https://user-images.githubusercontent.com/1725620/28153364-ffb4a20a-67df-11e7-9fa7-c58071c62734.png">

修正後

<img width="694" alt="after" src="https://user-images.githubusercontent.com/1725620/28153373-064fcb30-67e0-11e7-8ae4-4634aed12099.png">
