### PR TITLE
docset生成時のファイル名を生成する部分のバグを修正

### DIFF
--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -31,7 +31,7 @@ module RailsGuides
 
     def generate_docset
       require 'rails_guides/dash'
-      docset_name = "ruby_on_rails_guides_#{@version || @edge[0, 7]}%s.docset" % (@language.present? ? ".#@language" : '')
+      docset_name = ["ruby_on_rails_guides", @language, @version].compact.join(?_) + ".docset"
       Dash.generate(@output_dir, docset_name)
     end
 

--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -31,7 +31,7 @@ module RailsGuides
 
     def generate_docset
       require 'rails_guides/dash'
-      docset_name = "ruby_on_rails_guides_#@version%s.docset" % (@lang.present? ? ".#@lang" : '')
+      docset_name = "ruby_on_rails_guides_#{@version || @edge[0, 7]}%s.docset" % (@language.present? ? ".#@language" : '')
       Dash.generate(@output_dir, docset_name)
     end
 


### PR DESCRIPTION
RailsGuides の docset を生成時にファイル名を作成する部分の処理に不具合がありましたので、修正を行いました。

* `@version` の指定が無い場合に、rails/rails の最新コミットハッシュ値を利用する
* `@lang` -> `@language` への修正