### PR TITLE
文章中の原文を削除

### DIFF
--- a/guides/source/ja/association_basics.md
+++ b/guides/source/ja/association_basics.md
@@ -583,7 +583,6 @@ end
 モデルを先に作り、しばらく経過してから関連を追加で設定する場合は、`add_column`マイグレーションを作成して、必要な外部キーをモデルのテーブルに追加するのを忘れないようにしてください。
 
 クエリのパフォーマンスを向上させたり、外部キー制約が正しくデータを参照しているかを保証するために、インデックスを追加するのは良い方法です。
-performance and a foreign key constraint to ensure referential data integrity
 
 ```ruby
 class CreateBooks < ActiveRecord::Migration[5.0]


### PR DESCRIPTION
説明中に原文が混ざっていたので削除しました。文章自体は翻訳済みだと思われます。

修正前

<img width="662" alt="before" src="https://user-images.githubusercontent.com/1725620/28219640-a4aa59c2-68f7-11e7-98f9-3a5b1f32bdcd.png">

修正後

<img width="658" alt="after" src="https://user-images.githubusercontent.com/1725620/28219650-ab1e9322-68f7-11e7-818d-b190dc38bd66.png">
