### PR TITLE
インラインコードブロックの修正

### DIFF
--- a/guides/source/ja/association_basics.md
+++ b/guides/source/ja/association_basics.md
@@ -1923,7 +1923,7 @@ person.articles << article unless person.articles.include?(article)
 * `collection.size`
 * `collection.find(...)`
 * `collection.where(...)`
-* `collection.exists?(...)    ... 
+* `collection.exists?(...)`
 * `collection.build(attributes = {})`
 * `collection.create(attributes = {})`
 * `collection.create!(attributes = {})`


### PR DESCRIPTION
テキスト中にコードを埋め込めるインラインコードブロックの記述が間違っていたので修正しました。

修正前

<img width="360" alt="before" src="https://user-images.githubusercontent.com/1725620/28222842-155dffaa-6904-11e7-9f79-39132978537a.png">

修正後

<img width="361" alt="after" src="https://user-images.githubusercontent.com/1725620/28222850-1a38ae3a-6904-11e7-94a8-0dea8d43e005.png">
