### PR TITLE
Removed translated English portion in association basics

### DIFF
--- a/guides/source/ja/association_basics.md
+++ b/guides/source/ja/association_basics.md
@@ -1026,7 +1026,7 @@ class Author < ApplicationRecord
 end 
 ```
 
-上の例の場合、Bookクラスは、関連付けられているAuthorのタイムスタンプを保存時またはdestroy時に更新します。 In this case, saving or destroying a book will update the timestamp on the associated author. 更新時に特定のタイムスタンプ属性を指定することもできます。
+上の例の場合、Bookクラスは、関連付けられているAuthorのタイムスタンプを保存時またはdestroy時に更新します。更新時に特定のタイムスタンプ属性を指定することもできます。
 
 ```ruby
 class Book < ApplicationRecord


### PR DESCRIPTION
https://railsguides.jp/association_basics.html#touch
issue#465に投稿されていた英文をassociation_basics.mdから外しました。