### PR TITLE
Add description about installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,16 @@ https://railstutorial.jp/
 
 本リポジトリにPull Requestを送付したい方は、下記を参照してください。    
 
-### 1. HTMLファイルの生成 (Jekyll)
+### 1. 既存のHTMLファイルをローカルで生成および確認(Jekyll)
+
+(rubyのバージョンは[.ruby_version](https://github.com/yasslab/railsguides.jp/blob/master/.ruby-version)に記載があります。)
+
+1. `$ bundle install`
+2. `$ bundle exec rake assets:precompile`
+3. `$ bundle exec jekyll server`
+4. localhost:4000 から既存のHTMLファイルを確認する
+
+### 2. 編集したHTMLをローカルで生成および確認 (Jekyll)
 
 1. `/guides/source/ja` 内の Markdown ファイルを編集する
 2. `$ bundle exec rake assets:precompile` 
@@ -35,7 +44,7 @@ https://railstutorial.jp/
 4. localhost:4000 から変更結果を確認する
 5. (問題なければ) PRを送付する
 
-### 2. CI と Heroku
+### 3. CI と Heroku
 
 - PRが送られると、[railsguides.jpのTravis CI](https://travis-ci.org/yasslab/railsguides.jp) が走ります。
 - CIが通らなかった場合は、該当箇所を修正してください。


### PR DESCRIPTION
変更操作の前に、現状動作を確認する、という手順を追加したいです。

【現状】
プルリクエストを送るとき、[Railsガイドの生成方法](https://github.com/yasslab/railsguides.jp#rails%E3%82%AC%E3%82%A4%E3%83%89%E3%81%AE%E7%94%9F%E6%88%90%E6%96%B9%E6%B3%95)
には、変更済みのコードの手元での確認方法の手順の記載があります。

【問題?】
変更をはじめる前に、手元で環境を構築する手順を想像する必要がありました。

【期待】
手元でまずは既存のHTMLを確認しよう、という手順の記載があると、迷いなく進められると思いました。

【変更案】
[HTMLファイルの生成 (Jekyll)](https://github.com/yasslab/railsguides.jp#1-html%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%AE%E7%94%9F%E6%88%90-jekyll) の前に、「既存のHTMLファイルをローカルで生成および確認(Jekyll)
」を追加するのはいかがでしょうか?

よろしくお願いいたします。