### PR TITLE
Fix #608: Invalid byte sequence in US-ASCII

### DIFF
--- a/yasslab/Rakefile
+++ b/yasslab/Rakefile
@@ -74,7 +74,7 @@ namespace :guides do
     desc "Generate HTML guides"
     task html: :encoding do
       ENV["WARNINGS"] = "1" # authors can't disable this
-      ruby "rails_guides.rb"
+      load "rails_guides.rb"
     end
 
     desc "Generate .mobi file. The kindlegen executable must be in your PATH. You can get it for free from http://www.amazon.com/gp/feature.html?docId=1000765211"


### PR DESCRIPTION
cf. https://github.com/yasslab/railsguides.jp/issues/608