### PR TITLE
Active Storageの概要でconfigを書く設定ファイル名が間違っているのを修正

### DIFF
--- a/guides/source/ja/active_storage_overview.md
+++ b/guides/source/ja/active_storage_overview.md
@@ -72,7 +72,7 @@ config.active_storage.service = :amazon
 
 ### Disk Service
 
-`config/environments/production.rb`にDiskサービスを宣言してください。
+`config/storage.yml`にDiskサービスを宣言してください。
 
 ``` yaml
 local:


### PR DESCRIPTION
原文の該当箇所: https://github.com/rails/rails/blame/master/guides/source/active_storage_overview.md#L88