### PR TITLE
Update action_cable_overview.md

### DIFF
--- a/guides/source/ja/action_cable_overview.md
+++ b/guides/source/ja/action_cable_overview.md
@@ -282,7 +282,7 @@ class ChatChannel < ApplicationCable::Channel
   end
 
   def receive(data)
-    ChatChannel.broadcast_to("chat_#{params[:room]}", data)
+    ActionCable.server.broadcast("chat_#{params[:room]}", data)
   end
 end
 ```


### PR DESCRIPTION
receive で受け取ったメッセージをブロードキャストする際の クラス.メソッド 名が原文と異っています。

http://guides.rubyonrails.org/v5.0/action_cable_overview.html#rebroadcasting-a-message