### PR TITLE
翻訳を少し修正

### DIFF
--- a/guides/source/ja/upgrading_ruby_on_rails.md
+++ b/guides/source/ja/upgrading_ruby_on_rails.md
@@ -151,7 +151,7 @@ end
 
 ### Rails コントローラのテスト
 
-#### `rails-controller-testing`からヘルパーメソッドを抽出する
+#### いくつかのヘルパーメソッドを `rails-controller-testing` に抽出
 
 `assigns`メソッドと`assert_template`メソッドは`rails-controller-testing` gemに移転しました。これらのメソッドを引き続きコントローラのテストで使いたい場合は、Gemfileに`gem 'rails-controller-testing'`を追加してください。
 


### PR DESCRIPTION
原文を見ると少し違和感があったので翻訳を少し直しました。  ( 意味的には恐らく一緒だとは思うのですが `rails-controller-testing` が主体になっているのはちょっと違和感がありました）

```
4.5.1 Extraction of some helper methods to rails-controller-testing
```

```diff
-#### `rails-controller-testing`からヘルパーメソッドを抽出する
+#### いくつかのヘルパーメソッドを `rails-controller-testing` に抽出
```