### PR TITLE
Fix typo of block parameter name

### DIFF
--- a/guides/source/ja/active_record_querying.md
+++ b/guides/source/ja/active_record_querying.md
@@ -408,7 +408,7 @@ end
 `find_in_batches`はモデルクラスの上で動きます。これまでと同様に、リレーションについても同様です。
 
 ```ruby
-Invoice.pending.find_in_batches do |invoice|
+Invoice.pending.find_in_batches do |invoices|
   pending_invoices_export.add_invoices(invoices)
 end
 ```


### PR DESCRIPTION
いつもドキュメントにお世話になっています。
find_in_batches  に関する記述での typo の修正です。