### PR TITLE
Herokuの脆弱性の対応

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,7 +430,7 @@ GEM
       selenium-webdriver
       thor
     racc (1.4.14)
-    rack (2.0.3)
+    rack (2.0.5)
     rack-cache (1.7.0)
       rack (>= 0.4)
     rack-jekyll (0.3.5)
@@ -540,7 +540,7 @@ GEM
       thread (~> 0.1.7)
     spoon (0.0.6)
       ffi
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-export (1.0.0)


### PR DESCRIPTION
Herokuの脆弱性の対応を行った
今回は bundle update sprocketsで対応した
cf. https://blog.heroku.com/rails-asset-pipeline-vulnerability