### PR TITLE
マイグレーションの作成は常に必要になっていました。

### DIFF
--- a/guides/source/ja/active_storage_overview.md
+++ b/guides/source/ja/active_storage_overview.md
@@ -30,7 +30,7 @@ PDFやビデオなどの非画像アップロードの画像表現を生成し�
 ## セットアップ
 
 Active Storageは、アプリケーションのデータベースで `active_storage_blobs`と`active_storage_attachments`という名前の2つのテーブルを使用します。
-新しいアプリケーションを作成した（またはアプリケーションをRails 5.2にアップグレードした）後、`rails active_storage:install`を実行して、これらのテーブルを作成する移行を生成します。 
+新規アプリケーション作成後または既存のアプリケーションをRails 5.2にアップグレードした後に、`rails active_storage:install`を実行して、これらのテーブルを作成する移行を生成します。 
 移行を実行するには`rails db:migrate`を使用してください。
 
 Active Storageのサービスを`config/storage.yml`で宣言してください。 アプリケーションが使用するサービスごとに、名前と必要な構成を指定します。 

--- a/guides/source/ja/active_storage_overview.md
+++ b/guides/source/ja/active_storage_overview.md
@@ -30,10 +30,8 @@ PDFやビデオなどの非画像アップロードの画像表現を生成し�
 ## セットアップ
 
 Active Storageは、アプリケーションのデータベースで `active_storage_blobs`と`active_storage_attachments`という名前の2つのテーブルを使用します。
-アプリケーションをRails 5.2にアップグレードした後、`rails active_storage:install`を実行して、これらのテーブルを作成する移行を生成します。 
+新しいアプリケーションを作成した（またはアプリケーションをRails 5.2にアップグレードした）後、`rails active_storage:install`を実行して、これらのテーブルを作成する移行を生成します。 
 移行を実行するには`rails db:migrate`を使用してください。
-
-新しいRails 5.2アプリケーションで`rails active_storage:install`を実行する必要はありません。マイグレーションは自動的に生成されます。
 
 Active Storageのサービスを`config/storage.yml`で宣言してください。 アプリケーションが使用するサービスごとに、名前と必要な構成を指定します。 
 次の例では、`local`、`test`、`amazon`という3つのサービスを宣言しています。


### PR DESCRIPTION
新しくアプリを作った時でもマイグレーションファイルが作られなかったので原著を確認したところ、常に「rails active_storage:install」が必要になっていました。

https://guides.rubyonrails.org/active_storage_overview.html#setup