### PR TITLE
Fix reverse_update highlight and wording

### DIFF
--- a/guides/source/ja/active_support_core_extensions.md
+++ b/guides/source/ja/active_support_core_extensions.md
@@ -2560,7 +2560,7 @@ NOTE: 定義ファイルの場所は`active_support/core_ext/hash/reverse_merge.
 
 `reverse_update`メソッドは、上で説明した`reverse_merge!`の別名です。
 
-WARN: `reverse_update`には破壊的なバージョンはありません。
+WARNING: `reverse_update`には!のついたバージョンはありません。
 
 NOTE: 定義ファイルの場所は`active_support/core_ext/hash/reverse_merge.rb`です。
 


### PR DESCRIPTION
* WARNING が WARN と(おそらくtypoに)なっていて highlight されていなかった部分を修正
* bang が 破壊的と訳されていたが、 reverse_update 自体が破壊的なメソッドであるため意味が通らなくなっていた部分を修正