### PR TITLE
[Active Model の基礎] Dirtyモジュールの attr_name_was の結果を修正しました

### DIFF
--- a/guides/source/ja/active_model_basics.md
+++ b/guides/source/ja/active_model_basics.md
@@ -168,7 +168,7 @@ person.first_name_changed? # => true
 
 ```ruby
 # attr_name_was accessor
-person.first_name_was # => "First Name"
+person.first_name_was # => nil
 ```
 
 変更された属性の、直前の値と現在の値を両方返します。変更があった場合は配列を返し、変更がなかった場合はnilを返します。


### PR DESCRIPTION
- 修正箇所
以下の `attr_name_was accessor`
https://railsguides.jp/active_model_basics.html#%E5%B1%9E%E6%80%A7%E5%90%8D%E3%81%AB%E5%9F%BA%E3%81%A5%E3%81%84%E3%81%9F%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B5%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89

英語版を確認し、手元でも確認しましたが、 `nil` のようだったので修正しました！
https://guides.rubyonrails.org/active_model_basics.html#attribute-based-accessor-methods