### PR TITLE
omission 4 chapter 15 section on upgrade guide

### DIFF
--- a/guides/source/ja/upgrading_ruby_on_rails.md
+++ b/guides/source/ja/upgrading_ruby_on_rails.md
@@ -241,6 +241,16 @@ Rails 5 では、rakeに代わって`bin/rails`でタスクやテストを実行
 <% # Template Dependency: recordings/threads/events/* %>
 ```
 
+### `ActionView::Helpers::RecordTagHelper` は、外部のgemに移動（`record_tag_helper`）
+
+`content_tag_for` と `div_for` が削除され、 `content_tag` のみの利用が推奨されます。これらの古いメソッドを使い続けたい場合、 `record_tag_helper` gemをGemfileに追加してください。
+
+```ruby
+gem 'record_tag_helper', '~> 1.0'
+```
+
+詳細については[#18411](https://github.com/rails/rails/pull/18411)を参照してください。
+
 ### `protected_attributes` gem のサポートを終了
 
 `protected_attributes` gemのサポートは Rails 5 で終了しました。


### PR DESCRIPTION
Issue #713 で報告していた件です。
できる限り他の文章と合わせたつもりですが、おかしい点あればご指摘ください。

原文と該当のページは下記の通りです。

> 4.15 ActionView::Helpers::RecordTagHelper moved to external gem (record_tag_helper)
> 
> content_tag_for and div_for have been removed in favor of just using content_tag. To continue using the older methods, add the record_tag_helper gem to your Gemfile:
> 
> ```
> gem 'record_tag_helper', '~> 1.0'
> ```
> 
> See #18411 for more details.

https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#actionview-helpers-recordtaghelper-moved-to-external-gem-record-tag-helper