### PR TITLE
Redisキャッシュストアを使う際の注意文を修正

### DIFF
--- a/guides/source/ja/caching_with_rails.md
+++ b/guides/source/ja/caching_with_rails.md
@@ -357,7 +357,7 @@ config.cache_store = :mem_cache_store, "cache-1.example.com", "cache-2.example.c
 
 Redisキャッシュストアは、Redisがサポートするメモリ最大値到達時のLRU（least-recently-used: 最も最近使われたキャッシュ）やLFU（least-frequently-used: 最も使用頻度の少ないキャッシュ）に基づくキーのエビクション（喪失）を利用して、Memcachedキャッシュサーバーのように振る舞います。
 
-デプロイに関するメモ: Redisのキーはデフォルトでは無期限なので、専用のRedisキャッシュサーバーを使うときはご注意ください。常設のRedisサーバーに期限付きのキャッシュデータを保存しないこと。詳しくは[Redis cache server setup guide](https://redis.io/topics/lru-cache)（英語）をご覧ください。
+デプロイに関するメモ: Redisのキーはデフォルトでは無期限なので、専用のRedisキャッシュサーバーを使うようにご注意ください。永続化用のRedisサーバーに期限付きのキャッシュデータを保存しないこと。詳しくは[Redis cache server setup guide](https://redis.io/topics/lru-cache)（英語）をご覧ください。
 
 Redisサーバーを「オールキャッシュ」で使う場合は、`maxmemory-policy`に`allkeys`ポリシーを設定します。Redis 4以降ではLFUエビクション（`allkeys-lfu`）がサポートされており、これはデフォルトの選択肢として非常によいものです。Redis 3以前では`allkeys-lru`を用いてLRUにすべきです。
 


### PR DESCRIPTION
## 概要

該当箇所の翻訳について、おそらく原文が意図している内容は

- 専用のRedisキャッシュサーバーを使うことを推奨する
- 永続化用の（キャッシュサーバーではない）Redisサーバーをキャッシュデータでいっぱいにしないこと

なのですが、該当箇所はそのような意図が伝わりづらいと感じたので変更しています。

## 参考にした記述

* RailsGuide 原文: https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-rediscachestore

> Deployment note: Redis doesn't expire keys by default, so take care to use a dedicated Redis cache server. Don't fill up your persistent-Redis server with volatile cache data! 

* EngineYardのblog記事: https://www.engineyard.com/blog/rails-5-2-redis-cache-store

> It is recommended to use a dedicated Redis server for cache purposes. If you're already using Redis in your application, you should get a separate server or start a second Redis process.