### PR TITLE
Fix description of String#humanize with acronym

### DIFF
--- a/guides/source/ja/active_support_core_extensions.md
+++ b/guides/source/ja/active_support_core_extensions.md
@@ -1677,7 +1677,7 @@ NOTE: 定義ファイルの場所は`active_support/core_ext/string/inflections.
 "_id".humanize                          # => "Id"
 ```
 
-"SSL"が頭字語と定義されている場合は以下のようにエラーになります。
+"SSL"が頭字語と定義されている場合は以下のようになります。
 
 ```ruby
 'ssl_error'.humanize # => "SSL error"


### PR DESCRIPTION
``` Ruby
require 'active_support'
require 'active_support/core_ext/string/inflections'

ActiveSupport::Inflector.inflections do |inflect|
  inflect.acronym 'SSL'
end

'ssl_error'.humanize
=> "SSL error"
```

[原著: 5.11.13 humanize](https://guides.rubyonrails.org/active_support_core_extensions.html#humanize)

Thanks :)