### PR TITLE
Add a space between URL and the rest

### DIFF
--- a/guides/source/ja/contributing_to_ruby_on_rails.md
+++ b/guides/source/ja/contributing_to_ruby_on_rails.md
@@ -123,7 +123,7 @@ Railsガイドの翻訳に貢献する
 
 Railsガイドを翻訳してくださるボランティアも歓迎いたします。次の手順に沿ってください。
 
-* https://github.com/rails/railsをforkします。
+* https://github.com/rails/rails をforkします。
 * 翻訳先の言語名に対応するフォルダをsourceフォルダの下に追加します。たとえば、イタリア語であればguides/source/it-ITフォルダを追加します。
 * *guides/source*に置かれているコンテンツファイルをそのフォルダ内にコピーして翻訳します。
 * HTMLファイルは**翻訳しないでください**（自動生成されます）。


### PR DESCRIPTION
リンク先が以下のようになってしまっていたのでスペースを入れました。
```
<a href="https://github.com/rails/rails%E3%82%92fork%E3%81%97%E3%81%BE%E3%81%99%E3%80%82">https://github.com/rails/railsをforkします。</a>
```
[4 Railsガイドの翻訳に貢献する](https://railsguides.jp/contributing_to_ruby_on_rails.html#rails%E3%82%AC%E3%82%A4%E3%83%89%E3%81%AE%E7%BF%BB%E8%A8%B3%E3%81%AB%E8%B2%A2%E7%8C%AE%E3%81%99%E3%82%8B)