### PR TITLE
Downgrade from bundler 2.0.1 → 1.17.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,4 +195,4 @@ RUBY VERSION
    ruby 2.6.0p0
 
 BUNDLED WITH
-   2.0.1
+   1.17.3


### PR DESCRIPTION
Bundler's [Version switching](https://bundler.io/guides/bundler_2_upgrade.html#version-autoswitch) on CircleCI causes error when running `bin/rails db:setup`(sample below). Even though only Bundler 2 is installed in system.

```
You must use Bundler 2 or greater with this lockfile.
Error: Exited with code 20
Step failed
```