### PR TITLE
Change the expression of translation

### DIFF
--- a/guides/source/ja/active_support_core_extensions.md
+++ b/guides/source/ja/active_support_core_extensions.md
@@ -1342,7 +1342,7 @@ NOTE: 定義ファイルの場所は`active_support/core_ext/string/access.rb`�
 "equipment".pluralize # => "equipment"
 ```
 
-上の例でも示したように、Active Supportは不規則な複数形や非可算名詞をある程度扱えます。`config/initializers/inflections.rb`にあるビルトインのルールは拡張可能です。このファイルは`rails new`コマンドで生成され、コメントに説明が示されています。
+上の例でも示したように、Active Supportは不規則な複数形や非可算名詞をある程度扱えます。`config/initializers/inflections.rb`にあるビルトインのルールは拡張可能です。このファイルは`rails new`コマンド実行時にデフォルトで生成され、ファイルのコメントに説明が示されています。
 
 `pluralize`メソッドではオプションで`count`パラメータを使えます。もし`count == 1`を指定すると単数形が返されます。`count`がそれ以外の値の場合は複数形を返します(訳注: 英語では個数がゼロや小数の場合は複数形で表されます)。
 

--- a/guides/source/ja/active_support_core_extensions.md
+++ b/guides/source/ja/active_support_core_extensions.md
@@ -1342,7 +1342,7 @@ NOTE: 定義ファイルの場所は`active_support/core_ext/string/access.rb`�
 "equipment".pluralize # => "equipment"
 ```
 
-上の例でも示したように、Active Supportは不規則な複数形や非可算名詞をある程度扱えます。`config/initializers/inflections.rb`にあるビルトインのルールは拡張可能です。このファイルは`rails`コマンドで拡張可能であり、方法はコメントに示されています。
+上の例でも示したように、Active Supportは不規則な複数形や非可算名詞をある程度扱えます。`config/initializers/inflections.rb`にあるビルトインのルールは拡張可能です。このファイルは`rails`コマンドで生成され、コメントに説明が示されています。
 
 `pluralize`メソッドではオプションで`count`パラメータを使えます。もし`count == 1`を指定すると単数形が返されます。`count`がそれ以外の値の場合は複数形を返します(訳注: 英語では個数がゼロや小数の場合は複数形で表されます)。
 

--- a/guides/source/ja/active_support_core_extensions.md
+++ b/guides/source/ja/active_support_core_extensions.md
@@ -1342,7 +1342,7 @@ NOTE: 定義ファイルの場所は`active_support/core_ext/string/access.rb`�
 "equipment".pluralize # => "equipment"
 ```
 
-上の例でも示したように、Active Supportは不規則な複数形や非可算名詞をある程度扱えます。`config/initializers/inflections.rb`にあるビルトインのルールは拡張可能です。このファイルは`rails`コマンドで生成され、コメントに説明が示されています。
+上の例でも示したように、Active Supportは不規則な複数形や非可算名詞をある程度扱えます。`config/initializers/inflections.rb`にあるビルトインのルールは拡張可能です。このファイルは`rails new`コマンドで生成され、コメントに説明が示されています。
 
 `pluralize`メソッドではオプションで`count`パラメータを使えます。もし`count == 1`を指定すると単数形が返されます。`count`がそれ以外の値の場合は複数形を返します(訳注: 英語では個数がゼロや小数の場合は複数形で表されます)。
 


### PR DESCRIPTION
`railsコマンドで拡張可能`とありますが、railsコマンドでは拡張ではなく生成では？と思い更新させて頂きました😃
ご確認の程よろしくお願いいたします。

[FYI]
厳密には`rails new`コマンドだと思うので原著にもPR出してみました🐱‍🏍
https://github.com/rails/rails/pull/35514

### 原著
Built-in rules can be extended in config/initializers/inflections.rb. That file is generated by the rails command and has instructions in comments.