### PR TITLE
Update Mailer Views sample code description

### DIFF
--- a/guides/source/ja/action_mailer_basics.md
+++ b/guides/source/ja/action_mailer_basics.md
@@ -331,7 +331,7 @@ class UserMailer < ApplicationMailer
 end
 ```
 
-上のコードは、HTMLの部分を'another_template.html.erb'テンプレートでレンダリングし、テキスト部分を`:text`でレンダリングしています。レンダリングのコマンドはAction Controllerで使われているものと同じなので、`:text`、`:inline`などのオプションもすべて同様に利用できます。
+上のコードは、HTMLの部分を'another_template.html.erb'テンプレートでレンダリングし、テキスト部分をプレーンテキストでレンダリングしています。レンダリングのコマンドはAction Controllerで使われているものと同じなので、`:text`、`:inline`などのオプションもすべて同様に利用できます。
 
 #### メイラービューをキャッシュする
 


### PR DESCRIPTION
サンプルコード内で`:text`は使用していないのでtypoかなと思いました🤔

## 参考
### Guide内のサンプルコード

```ruby
class UserMailer < ApplicationMailer
  default from: 'notifications@example.com'

  def welcome_email
    @user = params[:user]
    @url  = 'http://example.com/login'
    mail(to: @user.email,
         subject: '私の素敵なサイトへようこそ') do |format|
      format.html { render 'another_template' }
      format.text { render plain: 'Render text' }
    end
  end
end
```

### 原著

This will render the template 'another_template.html.erb' for the HTML part and use the rendered text for the text part.