### PR TITLE
Fixed tab for markdown code inline

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -435,7 +435,7 @@ Rendered recordings/threads/_thread.html.erb in 1.5 ms [cache miss]
       'X-Permitted-Cross-Domain-Policies' => 'none',
       'Referrer-Policy' => 'strict-origin-when-cross-origin'
     }
-    ```
+    ```
 
 * `config.action_dispatch.default_charset`: すべてのレンダリングで使うデフォルトの文字セットを指定します。デフォルトは`nil`です。
 


### PR DESCRIPTION
タブの空白文字がおかしく、インラインが正しく表現できていなかったので修正しました🐱‍🏍