### PR TITLE
Add default for `config.action_view.raise_on_missing_translations`

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -526,7 +526,7 @@ config.action_dispatch.rescue_responses = {
 
 デフォルト設定は`true`で、その場合`/admin/posts/_post.erb`にあるパーシャルを使います。この値を`false`にすると、`/posts/_post.erb`がレンダリングされます。この動作は、`PostsController`などの名前空間化されていないコントローラでレンダリングした場合と同じです。
 
-* `config.action_view.raise_on_missing_translations`: i18nで訳文が見つからない場合にエラーを発生するかどうかを指定します。
+* `config.action_view.raise_on_missing_translations`: i18nで訳文が見つからない場合にエラーを発生するかどうかを指定します。デフォルトは`false`です。
 
 * `config.action_view.automatically_disable_submit_tag`: クリック時に`submit_tag`を自動的に無効にするべきかどうかを指定します。デフォルトは`true`です。
 


### PR DESCRIPTION
https://github.com/rails/rails/pull/35724 のバックポートになります。

そもそもの確認をさせて下さい
https://github.com/yasslab/railsguides.jp/pull/806 でお話あった様に、
こういった差分コミットは不要との認識で合っていますか？？
もしこのPRも不要であればcloseするのでご教示ください🙏