### PR TITLE
Delete description `ActionDispatch::Head`

### DIFF
--- a/guides/source/ja/rails_on_rack.md
+++ b/guides/source/ja/rails_on_rack.md
@@ -285,10 +285,6 @@ Action Controllerの機能の多くはミドルウェアとして実装されて
 
 * Content-Security-Policyヘッダー設定用のDSLを提供します。
 
-**`ActionDispatch::Head`**
-
-* HEADリクエストを`GET`に変換して処理します。その上でbodyを空にしたレスポンスを返します(訳注: Rails4.0からはRack::Headを使うように変更されています)。
-
 **`Rack::Head`**
 
 * `HEAD`リクエストを`GET`に変換し、`GET`として処理します。


### PR DESCRIPTION
原著では、`ActionDispatch::Head` -> `Rack::Head` と名前の変更があったのみですが、翻訳では両方記載されているので、`ActionDispatch::Head`の項目を削除しました🙏
https://github.com/rails/rails/commit/1069641bbc48dce6b919fe4bfb3badc2b72b2546

https://github.com/yasslab/railsguides.jp/blame/master/guides/source/rails_on_rack.md#L283-L294
https://github.com/yasslab/railsguides.jp/blame/master/guides/source/ja/rails_on_rack.md#L288-L294

敢えての残しでしたらすいません🙏
ご確認の程よろしくお願いいたします🐱‍🏍