### PR TITLE
Update translation expression for engine

### DIFF
--- a/guides/source/ja/engines.md
+++ b/guides/source/ja/engines.md
@@ -349,7 +349,7 @@ module Blorgh
 end
 ```
 
-NOTE: この`has_many`は`Blorgh`モジュールの中にあるクラスの中で定義されています。これだけで、これらのオブジェクトに対して`Blorgh::Comment`モデルを使いたいという意図がRailsに自動的に認識されます。従って、ここで`:class_name`オプションを使うクラス名を指定する必要はありません。
+NOTE: この`has_many`は`Blorgh`モジュールの中にあるクラスの中で定義されています。これだけで、これらのオブジェクトに対して`Blorgh::Comment`モデルを使いたいという意図がRailsに自動的に認識されます。従って、ここで`:class_name`オプションを使用してクラス名を指定する必要はありません。
 
 続いて、記事を作成するためのフォームを作成する必要があります。フォームを追加するには、`app/views/blorgh/articles/show.html.erb`の`render @article.comments`呼び出しの直後に以下の行を追加します。
 


### PR DESCRIPTION
こちらの表現の方がより自然だと思ったのですがいかがでしょうか👀

### 原著

NOTE: Because the has_many is defined inside a class that is inside the Blorgh module, Rails will know that you want to use the Blorgh::Comment model for these objects, so there's no need to specify that using the :class_name option here.