### PR TITLE
ナビゲーションバーからホームのリンクを削除

### DIFF
--- a/guides/source/ja/layout.html.erb
+++ b/guides/source/ja/layout.html.erb
@@ -95,7 +95,6 @@
       <div class="wrapper clearfix">
 	<h1><a href="/" title="ホームに戻る">railsguides.jp</a></h1>
 	<ul class="nav">
-          <li><a class="nav-item" href="/">ホーム</a></li>
           <li class="guides-index guides-index-large">
             <a href="index.html" id="guidesMenu" class="guides-index-item nav-item">ガイド目次</a>
             <div id="guides" class="clearfix" style="display: none;">


### PR DESCRIPTION
## 背景
- ホームへのリンクはロゴでもできるので、必須ではない
- 「ガイド目次」が端にある方が良い
- ナビゲーションバーに他のリンクを追加したい

## やったこと
- ナビゲーションバーから「ホーム」のリンクを削除した
