### PR TITLE
訳文修正 active_storage_overview.md

### DIFF
--- a/guides/source/ja/active_storage_overview.md
+++ b/guides/source/ja/active_storage_overview.md
@@ -363,14 +363,14 @@ Active Storageは、付属のJavaScriptライブラリを使用して、クラ�
      <%= form.file_field :attachments, multiple: true, direct_upload: true %>
      ```
      
-3. それだけです！ アップロードはフォーム提出時に開始されます。
+3. それだけです！ アップロードはフォーム送信時に開始されます。
 
 ### ダイレクトアップロードのJavascriptイベント
 
 | Event name | Event target | Event data (`event.detail`) | Description |
 | --- | --- | --- | --- |
 | `direct-uploads:start` | `<form>` | None | ダイレクトアップロードフィールドのファイルを含むフォームが送信された。 |
-| `direct-upload:initialize` | `<input>` | `{id, file}` | フォーム提出後のすべてのファイルにディスパッチされる。 |
+| `direct-upload:initialize` | `<input>` | `{id, file}` | フォーム送信後のすべてのファイルにディスパッチされる。 |
 | `direct-upload:start` | `<input>` | `{id, file}` | 直接アップロードが開始されている。 |
 | `direct-upload:before-blob-request` | `<input>` | `{id, file, xhr}` | アプリケーションにダイレクトアップロードメタデータを要求する前。 |
 | `direct-upload:before-storage-request` | `<input>` | `{id, file, xhr}` | ファイルを保存するリクエストを出す前。 |


### PR DESCRIPTION
`form submission` の訳を「フォーム提出」から「フォーム送信」に修正してみました。