### PR TITLE
Active Storageの不足部分追加

### DIFF
--- a/guides/source/ja/active_storage_overview.md
+++ b/guides/source/ja/active_storage_overview.md
@@ -257,6 +257,22 @@ end
 @message.images.attached?
 ```
 
+### File/IO Objectsを送付する
+
+HTTPリクエスト経由で届かないファイルを添付する必要がある場合があります。例えば、ディスクに生成したファイル、またはユーザーが送信したURLからダウンロードしたファイル等を添付したい。または、モデルテストでfixtureファイルを添付したい等のケースです。これらを実現する為には最低１つ以上のオープンIOオブジェクトとファイル名を含むハッシュを用意します。
+
+```ruby
+@message.image.attach(io: File.open('/path/to/file'), filename: 'file.pdf')
+```
+
+可能であれば、コンテントタイプも入力してください。Active Storageは与えられたデータからファイルのコンテントタイプを判断しようとしますが、できない場合は提供したコンテントタイプを使用します。
+
+```ruby
+@message.image.attach(io: File.open('/path/to/file'), filename: 'file.pdf', content_type: 'application/pdf')
+```
+
+コンテントタイプを指定せず、Active Storageがファイルのコンテントタイプを自動的に判別できない場合は、デフォルトで`application/octet-stream`が設定されます。
+
 モデルに添付されたファイルを削除する
 -----------------------------
 


### PR DESCRIPTION
以下の箇所の翻訳の追加を行いました。
修正箇所ございましたら、指摘よろしくお願いします。

https://guides.rubyonrails.org/active_storage_overview.html#attaching-file-io-objects

<!--
railsguides.jp では更新箇所のみを効率的に翻訳するため、rails/rails や edgeguides との差分翻訳は基本的にマージしていません。差分翻訳を行う場合は https://github.com/yasslab/railsguides.jp/tree/master/guides/source にあるファイルまたはコミットとの差分を更新していただけると嬉しいです!

🆗 マージ可能なPR例:
https://github.com/yasslab/railsguides.jp/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

🆖 マージしづらいPR例:
https://github.com/rails/rails/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

更新箇所のみを効率的に翻訳する方法については https://github.com/yasslab/railsguides.jp/pull/815 をご参照ください (＞人＜ )✨
-->

