### PR TITLE
[Layouts and Rendering in Rails]Delete overlapped description

### DIFF
--- a/guides/source/ja/layouts_and_rendering.md
+++ b/guides/source/ja/layouts_and_rendering.md
@@ -620,8 +620,6 @@ redirect_to photos_url
 
 `redirect_back`を使うと、ユーザを直前のページに戻すことができます。戻る場所は`HTTP_REFERER`ヘッダを利用していますが、これはブラウザが必ず設定しているとは限りません。そのため、`fallback_location`は必ず設定しなければなりません。
 
-`redirect_back`を使うと、ユーザを直前のページに戻すことができます。戻り先の場所は`HTTP_REFERER`ヘッダーから取り出されますが、これがブラウザ側で設定される保証はありません。したがって、ここでは`fallback_location`を指定する必要があります。
-
 ```ruby
 redirect_back(fallback_location: root_path)
 ```


### PR DESCRIPTION
<!--
railsguides.jp では更新箇所のみを効率的に翻訳するため、rails/rails や edgeguides との差分翻訳は基本的にマージしていません。差分翻訳を行う場合は https://github.com/yasslab/railsguides.jp/tree/master/guides/source にあるファイルまたはコミットとの差分を更新していただけると嬉しいです!

🆗 マージ可能なPR例:
https://github.com/yasslab/railsguides.jp/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

🆖 マージしづらいPR例:
https://github.com/rails/rails/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

更新箇所のみを効率的に翻訳する方法については https://github.com/yasslab/railsguides.jp/pull/815 をご参照ください (＞人＜ )✨
-->

「レイアウトとレンダリング」の「[2.3 redirect_toを使用する](https://railsguides.jp/layouts_and_rendering.html#redirect-to%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%99%E3%82%8B)」にある `redirect_back` の説明が重複していました。