### PR TITLE
Fix typo

### DIFF
--- a/guides/source/ja/active_record_querying.md
+++ b/guides/source/ja/active_record_querying.md
@@ -84,7 +84,7 @@ Active Recordでは、データベースからオブジェクトを取り出す�
 * `select`
 * `where`
 
-検索メソッドは`where`や`group`と行ったコレクションを返したり、`ActiveRecord::Relation`のインスタンスを返します。また、`find`や`first`などの１つのエンティティを検索するメソッドの場合、そのモデルのインスタンスを返します。
+検索メソッドは`where`や`group`といったコレクションを返したり、`ActiveRecord::Relation`のインスタンスを返します。また、`find`や`first`などの１つのエンティティを検索するメソッドの場合、そのモデルのインスタンスを返します。
 
 `Model.find(options)`という操作を要約すると以下のようになります。
 


### PR DESCRIPTION
細かいのですが、誤字修正の提案です。

`と行った` -> `といった`

<!--
railsguides.jp では更新箇所のみを効率的に翻訳するため、rails/rails や edgeguides との差分翻訳は基本的にマージしていません。差分翻訳を行う場合は https://github.com/yasslab/railsguides.jp/tree/master/guides/source にあるファイルまたはコミットとの差分を更新していただけると嬉しいです!

🆗 マージ可能なPR例:
https://github.com/yasslab/railsguides.jp/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

🆖 マージしづらいPR例:
https://github.com/rails/rails/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

更新箇所のみを効率的に翻訳する方法については https://github.com/yasslab/railsguides.jp/pull/815 をご参照ください (＞人＜ )✨
-->

