### PR TITLE
Redis cache store 設定の本家取り込み

### DIFF
--- a/guides/source/ja/caching_with_rails.md
+++ b/guides/source/ja/caching_with_rails.md
@@ -385,8 +385,8 @@ config.cache_store = :redis_cache_store, { url: ENV['REDIS_URL'] }
 これらをまとめたproduction向けRedisキャッシュストアは以下のような感じになります。
 
 ```ruby
-cache_servers = %w[ "redis://cache-01:6379/0", "redis://cache-02:6379/0", … ],
-config.cache_store = :redis_cache_store, url: cache_servers,
+cache_servers = %w(redis://cache-01:6379/0 redis://cache-02:6379/0)
+config.cache_store = :redis_cache_store, { url: cache_servers,
 
   connect_timeout: 30,  # Defaults to 20 seconds
   read_timeout:    0.2, # Defaults to 1 second
@@ -394,9 +394,10 @@ config.cache_store = :redis_cache_store, url: cache_servers,
 
   error_handler: -> (method:, returning:, exception:) {
     # Report errors to Sentry as warnings
-    Raven.capture_exception exception, level: 'warning",
+    Raven.capture_exception exception, level: 'warning',
       tags: { method: method, returning: returning }
   }
+}
 ```
 
 ### ActiveSupport::Cache::NullStore


### PR DESCRIPTION
本家修正の取り込み忘れだと思います。
古いままだと文法エラーにるため気がつきました。

本家コミット: https://github.com/rails/rails/commit/a6b82a37
railsguides.jp: https://github.com/yasslab/railsguides.jp/commit/883fc4fb