### PR TITLE
fix translation mismatch

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -301,7 +301,7 @@ config.middleware.delete Rack::MethodOverride
      config.i18n.fallbacks = [:tr, :en]
      ```
 
-     * ロケールごとに個別のフォールバックを設定することもできます。たとえば`:az`と`:de`に`:tr`を、`:da`に`:en`をそれぞれフォールバック先として指定する場合は、次のようにします。
+     * ロケールごとに個別のフォールバックを設定することもできます。たとえば`:az`に`:tr`を、`:da`に`:de`と`:en`をそれぞれフォールバック先として指定する場合は、次のようにします。
 
      ```ruby
      config.i18n.fallbacks = { az: :tr, da: [:de, :en] }


### PR DESCRIPTION
> Or you can set different fallbacks for locales individually. For example, if you want to use `:tr` for `:az` and `:de`, `:en` for `:da` as fallbacks, you can do it, like so

原文の区切りが分かりにくい感じですが、コード例も実際の挙動もこの修正のようになっています。

```ruby
    config.i18n.fallbacks = { az: :tr, da: [:de, :en] }
```

```ruby
>> I18n.fallbacks[:az]
=> [:az, :tr, :en] # :en is default
>> I18n.fallbacks[:da]
=> [:da, :de, :en]
```
