### PR TITLE
Fix unnatural translation.

### DIFF
--- a/guides/source/ja/engines.md
+++ b/guides/source/ja/engines.md
@@ -271,7 +271,7 @@ module Blorgh
 end
 ```
 
-NOTE: このクラスで継承されている`ArticlesController`クラスは、実際には`ApplicationController`ではなく、`Blorgh::ApplicationController`です。
+NOTE: この`ArticlesController`クラスが継承しているのは、アプリケーションの`ApplicationController`ではなく、`Blorgh::ApplicationController`です。
 
 `app/helpers/blorgh/articles_helper.rb`のヘルパーも同様に名前空間化されます。
 


### PR DESCRIPTION

#### The original english sentence.
The ArticlesController class inherits from Blorgh::ApplicationController, not the application's ApplicationController.

(ref. https://github.com/yasslab/railsguides.jp/blob/master/guides/source/engines.md#generating-an-article-resource)




#### Before:
NOTE: このクラスで継承されている`ArticlesController`クラスは、実際には`ApplicationController`ではなく、`Blorgh::ApplicationController`です。

#### After:
NOTE: この`ArticlesController`クラスが継承しているのは、アプリケーションの`ApplicationController`ではなく、`Blorgh::ApplicationController`です。

<!--
railsguides.jp では更新箇所のみを効率的に翻訳するため、rails/rails や edgeguides との差分翻訳は基本的にマージしていません。差分翻訳を行う場合は https://github.com/yasslab/railsguides.jp/tree/master/guides/source にあるファイルまたはコミットとの差分を更新していただけると嬉しいです!

🆗 マージ可能なPR例:
https://github.com/yasslab/railsguides.jp/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

🆖 マージしづらいPR例:
https://github.com/rails/rails/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

更新箇所のみを効率的に翻訳する方法については https://github.com/yasslab/railsguides.jp/pull/815 をご参照ください (＞人＜ )✨
-->

