### PR TITLE
6-0-stableを元に'独自のcredential'の項を更新

### DIFF
--- a/guides/source/ja/security.md
+++ b/guides/source/ja/security.md
@@ -1102,9 +1102,9 @@ Rails.application.config.content_security_policy_nonce_generator = -> request { 
 
 ### 独自のcredential
 
-Railsは、第三者のcredential（秘密鍵などの秘密情報）をリポジトリに保存するための`config/credentials.yml.enc`を生成します。生成したマスターキーをこのファイルに含めてRailsが暗号化し、`config/master.key`を除外したバージョンコントロールシステムに登録することで初めて意味があります。Railsは`ENV["RAILS_MASTER_KEY"]`にマスターキーがあるかどうかもチェックします。またRailsはproduction環境での起動時にcredentialを読み出すためにこのマスターキーを必要とします。
+Railsはcredentialファイル`config/credentials.yml.enc`に秘密鍵を保存します。このファイルは暗号化されているため直接編集することはできません。Railsはcredentialファイルを暗号化するためのマスターキーに`config/master.key`か環境変数`ENV["RAILS_MASTER_KEY"]`を使用します。credentialファイルは、マスターキーが安全に保存されている場合に限り、バージョン管理システムに登録することができます。
 
-保存したcredentialを編集するには、まず`bin/rails credentials:edit`を実行して新しい秘密鍵を生成し、続いて`rails credentials:edit`でcredentialを編集して秘密鍵を追加します。`credentials:edit`を実行すると、credentialファイルとマスターキーがまだ存在してなければ新たに作成します。
+新しい秘密鍵をcredentialファイルに追加するには、まず`rails secret`を実行して新しい秘密鍵を生成し、続いて`rails credentials:edit`でcredentialを編集して秘密鍵を追加します。`credentials:edit`を実行すると、credentialファイルとマスターキーがまだ存在してなければ新たに作成します。
 
 このファイルには、アプリケーションの`secret_key_base`がデフォルトで含まれますが、外部API向けのアクセスキーなどのcredentialを含めることもできます。
 


### PR DESCRIPTION
参照: https://github.com/rails/rails/blob/6-0-stable/guides/source/security.md#custom-credentials

（https://github.com/yasslab/railsguides.jp/tree/master/guides/source/security.md は5.xのようですが，https://github.com/yasslab/railsguides.jp/pull/871 で6.0が翻訳されているので）

余談ですが，secretsの訳語が秘密鍵なのは，公開鍵暗号のプライベートキーと紛らわしい感じがします。しかし適当な訳語が思いつきません。


<!--
railsguides.jp では更新箇所のみを効率的に翻訳するため、rails/rails や edgeguides との差分翻訳は基本的にマージしていません。差分翻訳を行う場合は https://github.com/yasslab/railsguides.jp/tree/master/guides/source にあるファイルまたはコミットとの差分を更新していただけると嬉しいです!

🆗 マージ可能なPR例:
https://github.com/yasslab/railsguides.jp/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

🆖 マージしづらいPR例:
https://github.com/rails/rails/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

更新箇所のみを効率的に翻訳する方法については https://github.com/yasslab/railsguides.jp/pull/815 をご参照ください (＞人＜ )✨
-->
