### PR TITLE
Edit active support core ext document

### DIFF
--- a/guides/source/ja/active_support_core_extensions.md
+++ b/guides/source/ja/active_support_core_extensions.md
@@ -1117,7 +1117,7 @@ NOTE: 定義は`active_support/core_ext/string/filters.rb`にあります。
 # => "Oh dear! Oh dear!..."
 ```
 
-`:omission`オプションを指定することで、省略文字 (…) をカスタマイズすることもできます。
+`:omission`オプションを指定することで、省略文字 (...) をカスタマイズすることもできます。
 
 ```ruby
 "Oh dear! Oh dear! I shall be late!".truncate(20, omission: '&hellip;')
@@ -1155,7 +1155,7 @@ NOTE: 定義は`active_support/core_ext/string/filters.rb`にあります。
 # => "Oh dear! Oh dear!..."
 ```
 
-`:omission`オプションを指定することで、省略文字 (…) をカスタマイズすることもできます。
+`:omission`オプションを指定することで、省略文字 (...) をカスタマイズすることもできます。
 
 ```ruby
 "Oh dear! Oh dear! I shall be late!".truncate_words(4, omission: '&hellip;')

--- a/guides/source/ja/active_support_core_extensions.md
+++ b/guides/source/ja/active_support_core_extensions.md
@@ -2027,9 +2027,6 @@ NOTE: 定義は`active_support/core_ext/enumerable.rb`にあります。
 
 `index_with`メソッドは、enumerableの要素をキーとして持つハッシュを生成します。値は渡されたデフォルト値か、ブロックで返されます。
 
-The method `index_with` generates a hash with the elements of an enumerable as keys. The value
-is either a passed default or returned in a block.
-
 ```ruby
 %i( title body created_at ).index_with { |attr_name| post.public_send(attr_name) }
 # => { title: "hey", body: "what's up?", … }


### PR DESCRIPTION
## Summary
- Remove redundant english lines which have already translated.
- Modify description on `:omission` options of `String#truncate` and `String#truncate_words` to be more precise.

## cf
- [String#truncate](https://github.com/yasslab/railsguides.jp/blob/master/activesupport/lib/active_support/core_ext/string/filters.rb#L69)
- [String#truncate_words](https://github.com/yasslab/railsguides.jp/blob/master/activesupport/lib/active_support/core_ext/string/filters.rb#L99)