### PR TITLE
訳文修正（Railsエンジンガイド / on_loadフックでコードを変更する / 例2）

### DIFF
--- a/guides/source/ja/engines.md
+++ b/guides/source/ja/engines.md
@@ -1073,7 +1073,7 @@ ActionController::Base.prepend(MyActionControllerHelper)
 
 ```ruby
 ActiveSupport.on_load(:action_controller_base) { prepend MyActionControllerHelper }
-# selfがActiveRecord::Baseを指すので`#prepend`呼び出しが簡潔になる
+# selfがActionController::Baseを指すので`#prepend`呼び出しが簡潔になる
 ```
 
 ### 例3


### PR DESCRIPTION
[Railsエンジンガイド / on_loadフックでコードを変更する / 例2](https://railsguides.jp/engines.html#%E4%BE%8B2) のコード内のコメントで、ActionController::BaseがActiveRecord::Baseになっておりましたので1箇所修正をさせていただきました。

英語ドキュメント該当箇所: https://github.com/yasslab/railsguides.jp/blob/6e7e128b3d15af3a813f652aaadc79b851879c6a/guides/source/engines.md#example-2

日本語ドキュメント該当箇所: https://github.com/yasslab/railsguides.jp/blob/6e7e128b3d15af3a813f652aaadc79b851879c6a/guides/source/ja/engines.md#%E4%BE%8B2

ご確認よろしくお願いいたします。