### PR TITLE
アセットパイプラインの訳文修正

### DIFF
--- a/guides/source/ja/asset_pipeline.md
+++ b/guides/source/ja/asset_pipeline.md
@@ -862,7 +862,7 @@ TIP: 詳細については、production環境用Webサーバーのドキュメ�
 アセットのキャッシュストア
 ------------------
 
-デフォルトのSprocketsは、development環境とproduction環境で`tmp/cache/assets`にあるアセットをキャッシュします。これは以下のように変更できます。
+デフォルトのSprocketsは、development環境とproduction環境で`tmp/cache/assets`にアセットをキャッシュします。これは以下のように変更できます。
 
 ```ruby
 config.assets.configure do |env|


### PR DESCRIPTION
アセットパイプライン - [6 アセットのキャッシュストア](https://railsguides.jp/asset_pipeline.html#%E3%82%A2%E3%82%BB%E3%83%83%E3%83%88%E3%81%AE%E3%82%AD%E3%83%A3%E3%83%83%E3%82%B7%E3%83%A5%E3%82%B9%E3%83%88%E3%82%A2)の訳文を修正しました。 `tmp/cache/assets` にアセットが置いてある表現になっていましたが、実際はアセットのキャッシュを置く場所です。

原文 https://guides.rubyonrails.org/asset_pipeline.html#assets-cache-store

> By default, Sprockets caches assets in tmp/cache/assets in development and production environments. This can be changed as follows: