### PR TITLE
Update active_storage_overview.md

### DIFF
--- a/guides/source/ja/active_storage_overview.md
+++ b/guides/source/ja/active_storage_overview.md
@@ -634,7 +634,7 @@ end
 # インラインジョブ処理でただちにジョブを実行する
 config.active_job.queue_adapter = :inline
 
-# test環境では別のファイルストレージをもしいる
+# test環境では別のファイルストレージを使う
 config.active_storage.service = :local_test
 ```
 


### PR DESCRIPTION
誤字があったので修正しました。
（`もしいる` -> `もちいる` かと思いますが、`使う`に変更しました。）

<!--
railsguides.jp では更新箇所のみを効率的に翻訳するため、rails/rails や edgeguides との差分翻訳は基本的にマージしていません。差分翻訳を行う場合は https://github.com/yasslab/railsguides.jp/tree/master/guides/source にあるファイルまたはコミットとの差分を更新していただけると嬉しいです!

🆗 マージ可能なPR例:
https://github.com/yasslab/railsguides.jp/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

🆖 マージしづらいPR例:
https://github.com/rails/rails/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

更新箇所のみを効率的に翻訳する方法については https://github.com/yasslab/railsguides.jp/pull/815 をご参照ください (＞人＜ )✨
-->

