### PR TITLE
fix typo on active_model_basics.md

### DIFF
--- a/guides/source/ja/active_model_basics.md
+++ b/guides/source/ja/active_model_basics.md
@@ -265,7 +265,7 @@ email_contact.valid?     # => true
 email_contact.persisted? # => false
 ```
 
-`ActiveModel::Model`を`include`するクラスでは、Active Recordの場合と同様に`form_for`や`render`などのAction Viewヘルパーメソッドを使えるようになりま。
+`ActiveModel::Model`を`include`するクラスでは、Active Recordの場合と同様に`form_for`や`render`などのAction Viewヘルパーメソッドを使えるようになります。
 
 ### シリアライズ
 


### PR DESCRIPTION
`ActiveModel::Model`を`include`するクラスでは、Active Recordの場合と同様に`form_for`や`render`などのAction Viewヘルパーメソッドを使えるようになりま。
to
`ActiveModel::Model`を`include`するクラスでは、Active Recordの場合と同様に`form_for`や`render`などのAction Viewヘルパーメソッドを使えるようになります。

<!--
railsguides.jp では更新箇所のみを効率的に翻訳するため、rails/rails や edgeguides との差分翻訳は基本的にマージしていません。差分翻訳を行う場合は https://github.com/yasslab/railsguides.jp/tree/master/guides/source にあるファイルまたはコミットとの差分を更新していただけると嬉しいです!

🆗 マージ可能なPR例:
https://github.com/yasslab/railsguides.jp/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

🆖 マージしづらいPR例:
https://github.com/rails/rails/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

更新箇所のみを効率的に翻訳する方法については https://github.com/yasslab/railsguides.jp/pull/815 をご参照ください (＞人＜ )✨
-->

