### PR TITLE
autoload_pathsの誤訳を修正

### DIFF
--- a/guides/source/ja/constant_autoloading_and_reloading.md
+++ b/guides/source/ja/constant_autoloading_and_reloading.md
@@ -339,7 +339,7 @@ require 'erb'
 
 * アプリケーションとエンジンの`app`ディレクトリ以下にあるすべてのサブディレクトリ。`app/controllers`などが対象。`app`以下に置かれる`app/workers`などのカスタムディレクトリはすべて`autoload_paths`に自動的に属するので、デフォルトのディレクトリとする必要はない。
 
-* アプリケーションとエンジンのすべての`app/*/concerns`第2サブディレクトリ。
+* アプリケーションとエンジンの`app/{controllers,models}/concerns`。
 
 * `test/mailers/previews`ディレクトリ。
 


### PR DESCRIPTION
以下のURLに誤訳かも？という箇所を見つけたので、PR送らせていただきます。

https://railsguides.jp/constant_autoloading_and_reloading.html#autoload-paths

- 英語版: Second level directories app/{controllers,models}/concerns in the application and engines.
- 日本語版: アプリケーションとエンジンのすべてのapp/*/concerns第2サブディレクトリ。

英語版の`Second level directories`は`app/{controllers,models}/`を指しているよう思いますが、逆にわかりにくくなっていると思うので省略しました。

<!--
railsguides.jp では更新箇所のみを効率的に翻訳するため、rails/rails や edgeguides との差分翻訳は基本的にマージしていません。差分翻訳を行う場合は https://github.com/yasslab/railsguides.jp/tree/master/guides/source にあるファイルまたはコミットとの差分を更新していただけると嬉しいです!

🆗 マージ可能なPR例:
https://github.com/yasslab/railsguides.jp/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

🆖 マージしづらいPR例:
https://github.com/rails/rails/commit/9291a813694b4b443557c282ba1fbb0c8b909d27 に対応しました

更新箇所のみを効率的に翻訳する方法については https://github.com/yasslab/railsguides.jp/pull/815 をご参照ください (＞人＜ )✨
-->

