### PR TITLE
Update cafety concern for classic loader

### DIFF
--- a/guides/source/ja/upgrading_ruby_on_rails.md
+++ b/guides/source/ja/upgrading_ruby_on_rails.md
@@ -387,7 +387,7 @@ config.load_defaults "6.0"
 config.autoloader = :classic
 ```
 
-Rails 6アプリケーションでclassicオートローダーを使う場合は、Webサーバーやバックグラウンド処理におけるスレッド安全性上の懸念がありますので、development環境でconcurrency levelを1に設定することをおすすめします。
+Rails 6アプリケーションでclassicオートローダーを使う場合は、スレッド安全性上の懸念があるため、development環境ではWebサーバーやバックグラウンド処理のconcurrency levelを1に設定することをおすすめします。
 
 ### Active Storageの代入の振る舞いの変更
 


### PR DESCRIPTION
https://github.com/yasslab/railsguides.jp/commit/34fea92974db076e8d4d84ab834e3ca3eb796fe2 で追加された翻訳ですが、`concurrency levelを1に設定することをおすすめします。`の主語を明示する事でより分かりやすくなると思いました。
ご確認お願いします。

## 原著

> When using the Classic Autoloader in Rails 6 application it is recommended to set concurrency level to 1 in development environment, for the web servers and background processors, due to the thread-safety concerns.

https://github.com/rails/rails/blob/891ac4e2f1a9b63d3cbf2b1cadf976669ed89a1b/guides/source/upgrading_ruby_on_rails.md#eager-loading-and-autoloading-are-consistent