### PR TITLE
i18nのルーティングに関するgemの紹介箇所を更新

### DIFF
--- a/guides/source/ja/i18n.md
+++ b/guides/source/ja/i18n.md
@@ -271,7 +271,7 @@ get '/:locale' => 'dashboard#index'
 
 このルーティング宣言が他のルーティングを「食べてしまう」ようなことのないよう、**ルーティング宣言の順序** には十分ご注意ください。(この記述は`root :to`の直前に置くこともできます)
 
-NOTE: ルーティングに対してこのような形でシンプルに動作する、以下の2つのプラグインをチェックしてみてもよいかもしれません。Sven Fuchs作 [routing_filter](https://github.com/svenfuchs/routing-filter/tree/master) およびRaul Murciano作 [translate_routes](https://github.com/raul/translate_routes/tree/master)。
+NOTE: ルーティングに対してこのような形でシンプルに動作する、以下のようなさまざまなgemをチェックしてみてもよいかもしれません。[routing_filter](https://github.com/svenfuchs/routing-filter/tree/master)、[rails-translate-routes](https://github.com/francesc/rails-translate-routes)、[route_translator](https://github.com/enriclluelles/route_translator)。
 
 #### ロケールをユーザーが自由に設定する
 


### PR DESCRIPTION
原著では rails/rails@c6a06e8 で該当部分が更新されていました。

i18n.mdは他にも原著との差分が残っているようですが、こういう形で部分的にキャッチアップするPRを出しても問題ないでしょうか？