### PR TITLE
「お知らせ」のデザインの改善・色指定の記述更新

### DIFF
--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -17,7 +17,7 @@
     // height: 18px;
     width: auto;
     border-radius: 70px;
-    background: #5280dd;
+    background: $blue;
     word-wrap: break-word;
     border: one;
     -webkit-appearance: none;
@@ -32,7 +32,7 @@
         color: #fff !important;
         text-decoration: underline !important;
         &:hover {
-            color: #eee !important;
+            color: $gray-lighter !important;
         }
     }
 }

--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -13,13 +13,11 @@
 
 .announce {
     margin: 0px 0px 20px 0px;
-    padding: 0.001em 10px 0.001em 10px;
-    // height: 18px;
+    padding: 4px 10px 4px 10px;
     width: auto;
-    border-radius: 70px;
+    border-radius: 5px;
     background: $blue;
     word-wrap: break-word;
-    border: one;
     -webkit-appearance: none;
     h6 {
       color: #fff;
@@ -27,6 +25,7 @@
       font-size: .875em;
       text-align:  left;
       word-wrap: break-word;
+      margin: 4px 0;
     }
     a {
         color: #fff !important;


### PR DESCRIPTION
## 行ったこと
- デザインの改善(画像参照)
- 色の指定に変数を使用

#### Before
![image](https://user-images.githubusercontent.com/31533303/81148968-41dd5480-8fb8-11ea-9d77-ce3f6ca453b5.png)
#### After
![image](https://user-images.githubusercontent.com/31533303/81148739-c7acd000-8fb7-11ea-957d-c36227454247.png)
