### PR TITLE
Update active_support_core_extensions.md

### DIFF
--- a/guides/source/ja/active_support_core_extensions.md
+++ b/guides/source/ja/active_support_core_extensions.md
@@ -80,7 +80,7 @@ require 'active_support/all'
 
 ただし、これを実行してもActive Support全体がメモリに読み込まれるわけではないことにご注意ください。一部は`autoload`として設定されており、実際に使うまで読み込まれません。
 
-### Ruby on RailsアプリケーションでActive Supportを使う
+### Ruby on RailsアプリケーションにおけるActive Support
 
 Ruby on Railsアプリケーションでは、基本的にすべてのActive Supportを読み込みます。例外は`config.active_support.bare`を`true`に設定した場合です。このオプションを`true`にすると、フレームワーク自体が必要とするまでアプリケーションは拡張機能を読み込みません。また上で解説したように、読み込まれる拡張機能はあらゆる粒度で選択されます。
 


### PR DESCRIPTION
「Ruby on RailsアプリケーションでActive Supportを使う」の訳を改善します。


この「Ruby on RailsアプリケーションでActive Supportを使う」という訳に違和感がありました。

原文では「1.2 Active Support Within a Ruby on Rails Application」というタイトルになっています。
https://guides.rubyonrails.org/active_support_core_extensions.html#active-support-within-a-ruby-on-rails-application


いい訳はないかなとしばらく考えていたのですが、おそらくこれは「1.1 Stand-Alone Active Support」に対応する「1.2 Active Support Within a Ruby on Rails Application」かなと気が付きました。
つまり、1.1は単体でActive Supportを使う場合の章で、1.2はRailsと一緒にActive Supportを使う場合の章だと考えています。


そのため、1.2のタイトルの訳を「Ruby on RailsアプリケーションにおけるActive Support」としてみました。これは1.1の「単体のActive Support」と対になったタイトルになっているのではないかなと思います。