### PR TITLE
コードの背景色・スタイルを改善

### DIFF
--- a/guides/assets/_sass/color.scss
+++ b/guides/assets/_sass/color.scss
@@ -17,3 +17,5 @@ $black: #222;
 $gray-dark: #333;
 $gray-light: #999;
 $gray-lighter: #eee;
+
+$code-bg: #f4f4f4;

--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -96,9 +96,11 @@ pre, code {
   font-size: 1em;
   font-family: "Anonymous Pro", "Inconsolata", "Menlo", "Consolas", "Bitstream Vera Sans Mono", "Courier New", monospace;
   line-height: 1.5;
-  margin: 1.5em 0;
   overflow: auto;
   color: $black;
+}
+pre {
+  margin: 1em 0;
 }
 pre, tt, code {
  white-space: pre-wrap;       /* css-3 */
@@ -736,10 +738,6 @@ h6 {
 #subCol h3.chapter img {vertical-align: text-bottom;}
 #subCol li ul, li ol { margin:0 1.5em; }
 
-div.code_container {
-  background: #EEE url(../images/tab_grey.gif) no-repeat left top;
-  padding: 0.25em 1em 0.5em 48px;
-}
 
 .note {
   background: #fff9d8 url(../images/tab_note.gif) no-repeat left top;
@@ -1133,4 +1131,11 @@ code {
   border-radius: 2px;
   padding: 1px 0.3em;
   margin: 0 0.2em;
+}
+
+.code_container {
+  background: $code-bg;
+  padding: 0 1em;
+  border-radius: 5px;
+  border: solid $gray-lighter 2px;
 }

--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -1126,3 +1126,11 @@ table td, table th { padding: 9px 10px; text-align: left; }
   border:1px solid #e8e8e8;
   box-sizing: border-box;
 }
+
+/* code block style */
+code {
+  background-color: $gray-lighter;
+  border-radius: 2px;
+  padding: 1px 0.3em;
+  margin: 0 0.2em;
+}


### PR DESCRIPTION
読みやすいよう、背景色を改善しました。
左側にあった画像は不要な情報量が多いため削りました。
![image](https://user-images.githubusercontent.com/31533303/84457311-538fd700-ac9d-11ea-9ec7-f3650718cc78.png)

## 気になること
コードブロックの場合、黒背景のテーマのほうが見やすく、コードを見つけやすそうと思いました。ただ、工数が低いとはいえ理由があまりはっきりしていない状態で大きい見た目の変更を入れるのは避けたいため、一旦保留にしています。意見あれば共有いただけると嬉しいです＞＜ (ちなみに、Qiitaやnoteは黒背景でした) 
エンターテイメントというよりはドキュメントなので、作業時の見やすさを重視したいです。

一つ考えているのは、Railsチュートリアルのフォントのようにコードブロックのテーマを切り替えられる機能の実装です。(このPRではやりません💦)