### PR TITLE
目次表示の guidesIndex を呼び出すようにした

### DIFF
--- a/guides/source/ja/layout.html.erb
+++ b/guides/source/ja/layout.html.erb
@@ -240,6 +240,7 @@
     <script type="text/javascript" src="javascripts/jquery.min.js"></script>
     <script type="text/javascript" src="javascripts/responsive-tables.js"></script>
     <script type="text/javascript" src="javascripts/guides.js"></script>
+    <script type="text/javascript"> $(guidesIndex.bind); </script>
     <script async defer src="https://buttons.github.io/buttons.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## 起きたこと

ヘッダーの目次をクリックしてもポップダウンで表示されなくなった。

## やったこと

https://github.com/yasslab/railsguides.jp/commit/1cffee084aca66bfecc0ab8b12ccd8df464170d2 で目次を呼び出しの部分が消されていたので、再度追加しなおしました。