### PR TITLE
コードブロックの崩れ修正

### DIFF
--- a/guides/source/ja/routing.md
+++ b/guides/source/ja/routing.md
@@ -793,7 +793,7 @@ get '/stories', to: redirect('/articles')
 ```
 
 パスにマッチする動的セグメントを再利用してリダイレクトすることもできます。
-使うと
+
 ```ruby
 get '/stories/:name', to: redirect('/articles/%{name}')
 ```


### PR DESCRIPTION
改行がないために起きていたコードブロックの崩れを直しました。そのために、不要だと思われる文言を削除しました。

before:

<img width="300" alt="before" src="https://user-images.githubusercontent.com/31821663/84723194-01fa8b80-afc0-11ea-9b39-c3dcb468e3e6.png">


after:

<img width="300" alt="after" src="https://user-images.githubusercontent.com/31821663/84723250-1ccd0000-afc0-11ea-9108-9acf5fe1cac8.png">
