### PR TITLE
ページ上部の水色の背景色を明るく変更

### DIFF
--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -291,7 +291,7 @@ body {
 }
 
 #feature {
-  background: #d5e9f6 url(../images/feature_tile.gif) repeat-x;
+  background: $blue-light;
   color: $gray-dark;
   padding: 0.5em 0 1.5em;
 }


### PR DESCRIPTION
現状: 暗い雰囲気、infoブロックで使われている水色と統一されていません。
→ 雰囲気を明るくし、また他の水色と明るさを統一することにしました。
![image](https://user-images.githubusercontent.com/31533303/85098571-147dfa80-b236-11ea-9b11-cd26cbd77591.png)
