### PR TITLE
バージョン5.1のレイアウト調整

### DIFF
--- a/guides/source/ja/index.html.erb
+++ b/guides/source/ja/index.html.erb
@@ -28,22 +28,25 @@ Ruby on Rails ガイド：体系的に Rails を学ぼう
   <li><a class="github-button" href="https://github.com/yasslab/railsguides.jp" data-count-href="/yasslab/railsguides.jp/stargazers" data-count-api="/repos/yasslab/railsguides.jp#stargazers_count" data-count-aria-label="# stargazers on GitHub" aria-label="Star yasslab/railsguides.jp on GitHub">Star</a></li>
 </ol>
 
-<div id="subCol">
+<div id="subCol" class="remove-bg-color">
+  <!--
+  <aside id="toppage">
+    <a href="https://railsguides.jp/pro"><img src="images/bnr-pro-plan.jpg" alt="RailsガイドProプラン" /></a>
+  </aside>
+  -->
+
   <div class="ebook">
-    <a href="/options.html"><img id="ebook-ribbon" src="/images/rails_guides_ribbon.png"></a>
-    <a href="/options.html"><img id="ebook-left"   src="/images/rails_guides_ebook_left.png"></a>
-    <a href="/options.html"><img id="ebook-right"  src="/images/rails_guides_ebook_right.png"></a>
-    <!--
-	 <a href="/options.html"><img id="ebook-left-discount"   src="/images/rails_guides_ebook_discount.png"></a>
-	 <a href="/options.html"><img id="ebook-right"  src="/images/rails_guides_ebook_2_discount.png"></a>
+    <a href="https://railsguides.jp/ebook"><img id="ebook-ribbon" src="/images/rails_guides_ribbon.png"></a>
+    <a href="https://railsguides.jp/ebook"><img id="ebook-left"   src="/images/rails_guides_ebook_left.png"></a>
+    <a href="https://railsguides.jp/ebook"><img id="ebook-right"  src="/images/rails_guides_ebook_right.png"></a>
+    <!-- 電子書籍キャンペン中に表示
+    <a href="https://railsguides.jp/ebook"><img id="ebook-left-discount"   src="/images/rails_guides_ebook_discount.png"></a>
+    <a href="https://railsguides.jp/ebook"><img id="ebook-right"  src="/images/rails_guides_ebook_2_discount.png"></a>
     -->
-    <div class="ebook-button"><a href="/options.html">電子書籍版はコチラから</a></div>
+    <div class="ebook-button"><a href="https://railsguides.jp/ebook">電子書籍版はコチラから</a></div>
   </div>
 </div>
 <% end %>
-<div class="announce">
-  <h6><a href="https://rebuild.fm/100/">Rebuild.fm Episode #100</a> でRailsガイドを紹介して頂きました :)</h6>
-</div>
 
 <dl>
   <dd class="work-in-progress">このアイコンが付いているガイドは現在作業中 (Work in progress) であり、上部のガイド目次からは参照できません。作業中のガイドはそれなりに有用ではありますが、不完全な情報やエラーが含まれている可能性があります。</dd>

--- a/guides/source/ja/layout.html.erb
+++ b/guides/source/ja/layout.html.erb
@@ -58,7 +58,7 @@
     <meta name="msapplication-TileImage" content="images/favicons/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
   </head>
-  
+
   <body class="guide">
     <div id="fb-root"></div>
     <script>(function(d, s, id) {
@@ -187,17 +187,25 @@
 	<div id="footer">
 	  <div class="wrapper">
 	    <div class="sitemap">
-              <% %w(L C R).each do |position| %>
-		<dl class="<%= position %>">
-		  <% docs_for_sitemap(position).each do |section| %>
-		    <dt><%= section['name'] %></dt>
-		    <% finished_documents(section['documents']).each do |document| %>
-		      <dd><a href="<%= document['url'] %>"><%= document['name'] %></a></dd>
-		    <% end %>
-		  <% end %>
-		</dl>
-              <% end %>
-	    </div>
+        <% %w(L C R).each do |position| %>
+	    <dl class="<%= position %>">
+	      <% docs_for_sitemap(position).each do |section| %>
+          <dt><%= section['name'] %></dt>
+          <% finished_documents(section['documents']).each do |document| %>
+            <dd><a href="<%= document['url'] %>"><%= document['name'] %></a></dd>
+          <% end %>
+	      <% end %>
+	      <% if position == 'R' %>
+      		<dt>運営に関する情報</dt>
+      		<dd><a href="https://yasslab.jp/ja/" target="_blank" rel="noopener">運営会社</a></dd>
+      		<dd><a href="https://railsguides.jp/term-of-service">利用規約</a></dd>
+      		<dd><a href="https://railsguides.jp/policy">特定商取引法に基づく表記</a></dd>
+      		<dd><a href="https://yasslab.jp/ja/privacy" target="_blank" rel="noopener">プライバシーポリシー</a></dd>
+          <dd><a href="https://railsguides.jp/contact">お問い合わせ</a></dd>
+	      <% end %>
+	    </dl>
+          <% end %>
+    	</div>
 
 	    <ol class="trademark" style="padding-top: 20px">
 	      <li>本ガイドは<a href="https://creativecommons.org/licenses/by-sa/4.0/deed.ja">クリエイティブ・コモンズ 表示-継承 4.0 国際</a> (CC BY-SA 4.0) ライセンスに基づいて公開されています。また、「Rails」および「Ruby on Rails」という名称、そして Rails のロゴは、David Heinemeier Hansson による登録商標で、すべての権利を有しています。</li>


### PR DESCRIPTION
## やること
- [x] フッターの目次修正(運営に関する情報記載
- [x] トップの電子書籍バナーの調整
- [x] お知らせを非表示

古いバージョンのものを取り込んでもレイアウトが崩れないよう、修正しました