### PR TITLE
[ja-5.0] sdoc の github 指定を削除

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "rb-inotify", github: "matthewd/rb-inotify", branch: "close-handling", requi
 gem "stopgap_13632", platforms: :mri if RUBY_VERSION == "2.2.8"
 
 group :doc do
-  gem "sdoc", github: "robin850/sdoc", branch: "upgrade"
+  gem "sdoc"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators"
   gem "kindlerb", "~> 1.2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,14 +31,6 @@ GIT
       event_emitter
       websocket
 
-GIT
-  remote: https://github.com/robin850/sdoc.git
-  revision: 0e340352f3ab2f196c8a8743f83c2ee286e4f71c
-  branch: upgrade
-  specs:
-    sdoc (1.0.0.rc2)
-      rdoc (~> 5.0)
-
 PATH
   remote: .
   specs:
@@ -447,7 +439,7 @@ GEM
     rake (12.2.1)
     rb-fsevent (0.10.2)
     rb-readline (0.5.5)
-    rdoc (5.1.0)
+    rdoc (6.2.1)
     redcarpet (3.2.3)
     redis (4.0.1)
     redis-namespace (1.6.0)
@@ -507,6 +499,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sdoc (1.1.0)
+      rdoc (>= 5.0)
     selenium-webdriver (3.5.1)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
@@ -667,10 +661,11 @@ DEPENDENCIES
   redis-namespace
   resque
   resque-scheduler
+  rouge
   rspec
   rubocop (>= 0.47)
   sass-rails
-  sdoc!
+  sdoc
   sequel
   sidekiq
   sneakers

--- a/yasslab/Gemfile
+++ b/yasslab/Gemfile
@@ -22,7 +22,7 @@ gem "rack-contrib", github: "bigcartel/rack-contrib", branch: "master"
 gem "html-proofer"
 
 group :doc do
-  gem "sdoc", github: "robin850/sdoc", branch: "upgrade"
+  gem "sdoc"
   gem "redcarpet", "~> 3.2.3", platforms: :ruby
   gem "w3c_validators"
   gem "kindlerb", "~> 1.2.0"


### PR DESCRIPTION
## 起きたこと
- `ja-5.0`のブランチで `bundle install` を行うと、`sdoc`でgithubのログインが要求される

```zsh
 $ bundle install
Your Gemfile lists the gem puma (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once (per group).
While it's not a problem now, it could cause errors if you change the version of one of them later.
Your Gemfile lists the gem rack-cache (~> 1.2) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once (per group).
While it's not a problem now, it could cause errors if you change the version of one of them later.
Your Gemfile lists the gem sdoc (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once (per group).
While it's not a problem now, it could cause errors if you change the version of one of them later.
Your Gemfile lists the gem redcarpet (~> 3.2.3) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once (per group).
While it's not a problem now, it could cause errors if you change the version of one of them later.
Your Gemfile lists the gem w3c_validators (>= 0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once (per group).
While it's not a problem now, it could cause errors if you change the version of one of them later.
Your Gemfile lists the gem kindlerb (~> 1.2.0) more than once.
You should probably keep only one of them.
Remove any duplicate entries and specify the gem only once (per group).
While it's not a problem now, it could cause errors if you change the version of one of them later.
Fetching https://github.com/robin850/sdoc.git
Username for 'https://github.com': 
```

## 原因

`https://github.com/robin850/sdoc.git` がprivateレポジトリのため、ログインが要求される

## やったこと
- [x] Gemfille にある sdoc の github の指定を削除
  - 最新版ではhttps://github.com/yasslab/railsguides.jp/commit/c5934ad2ad261fbe6b76da824599c5d0771d9d3f#diff-0d2ae80640378d3b40b9d4dc2749d125R9-R10 のコミットで消される


