### PR TITLE
サイドバーにあるulにアイコンが反映されないよう修正

### DIFF
--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -663,7 +663,7 @@ h6 {
       font-size: 1em;
     }
   }
-  ul {
+  .wrapper > ul {
     margin-left: 0;
     @media screen and (max-width: 920px) {
       margin-right: 0;


### PR DESCRIPTION
サイドに有るulにアイコンが反映されないよう修正しました。
https://github.com/yasslab/railsguides.jp/pull/970 で行った改善により、次の画像のようにサイドバーのアイコンと被ってしまいました。
![image](https://user-images.githubusercontent.com/31533303/86547421-ea397600-bf73-11ea-9075-7c0b5b56d207.png)

直下のulのみアイコン表示されるよう修正しました。(サイドバーはさらに下の階層なのでアイコンが表示されない)