### PR TITLE
ガイド目次の他の構成要素においてAction Text の概要が重複している

### DIFF
--- a/guides/source/ja/documents.yaml
+++ b/guides/source/ja/documents.yaml
@@ -108,11 +108,6 @@
       name: Action Cable の概要
       url: action_cable_overview.html
       description: リアルタイム機能を実現するAction Cableの動作と、WebSocketsの利用法について解説します。
-    -
-      name: Action Text の概要
-      url: action_text_overview.html
-      description: リッチテキストコンテンツの扱い始めるのに必要なものについて解説します。
-
 
 -
   name: 高度なトピック


### PR DESCRIPTION
他の構成要素においてAction Text の概要が重複している。
オリジナルの該当箇所
https://github.com/rails/rails/blob/master/guides/source/documents.yaml#L89
https://github.com/rails/rails/blob/master/guides/source/documents.yaml#L105