### PR TITLE
コネクションの自動切り替えに関する誤訳を修正

### DIFF
--- a/guides/source/ja/active_record_multiple_databases.md
+++ b/guides/source/ja/active_record_multiple_databases.md
@@ -145,7 +145,7 @@ $ rails g migration CreateDogs name:string --database animals
 
 自動切り替え機能によって、アプリケーションはHTTP verbや直近の書き込みの有無に応じてprimaryからreplica、またはreplicaからprimaryへと切り替えます。
 
-アプリケーションがPOST、PUT、DELETE、PATCHのいずれかのリクエストを受け取ると、自動的にprimaryに書き込みます。書き込み後に指定の時間が経過すると、アプリケーションはprimaryから読み出します。アプリケーションがGETリクエストやHEADリクエストを受け取ると、直近の書き込みがなければreplicaから読み出します。
+アプリケーションがPOST、PUT、DELETE、PATCHのいずれかのリクエストを受け取ると、自動的にprimaryに書き込みます。書き込み後に指定の時間が経過するまでは、アプリケーションはprimaryから読み出します。アプリケーションがGETリクエストやHEADリクエストを受け取ると、直近の書き込みがなければreplicaから読み出します。
 
 コネクション自動切り替えのミドルウェアを有効にするには、アプリケーション設定に以下の行を追加するか、コメントを解除します。
 


### PR DESCRIPTION
[原文](https://guides.rubyonrails.org/active_record_multiple_databases.html#activating-automatic-connection-switching)では下記のような説明となっていますので、指定の時間が経過してからprimaryから読み出すというよりは、指定の時間が経過するまではprimaryから読み出すという説明が正しそうです。

> If the application is ~. For the specified time after the write the application will read from the primary. 

```diff
- 書き込み後に指定の時間が経過すると、アプリケーションはprimaryから読み出します。
+ 書き込み後に指定の時間が経過するまでは、アプリケーションはprimaryから読み出します。
```

関連するRailsの実装: https://github.com/rails/rails/commit/0abcec416b6ec11faffa03d40e5661c0a4a8b092

