### PR TITLE
Action Controller の概要 - セッションメカニズムにおける翻訳のご提案

### DIFF
--- a/guides/source/ja/action_controller_overview.md
+++ b/guides/source/ja/action_controller_overview.md
@@ -335,8 +335,8 @@ CookieStoreには約4KBのデータを保存できます。他のセッション
 別のセッションメカニズムが必要な場合は、イニシャライザを変更することで切り替えられます。
 
 ```ruby
-# デフォルトのcookieベースのセッションに代えてデータベースセッションを
-# 使う場合は、機密情報を保存しないこと。
+# Cookie ベースのデフォルトは特に機密性の高い情報を保存する目的で使うべきではありません。
+# 代わりにデータベースをセッションに使います。
 # (セッションテーブルの作成は"rails g active_record:session_migration"で行なう)
 # Rails.application.config.session_store :active_record_store
 ```


### PR DESCRIPTION
以下の原文について、内容を鑑みて翻訳の修正をご提案いたします。

>Use the database for sessions instead of the cookie-based default,
>which shouldn't be used to store highly confidential information

cookie ベースのセッションメカニズムよりもデータベースによるセッションのほうが一般にセキュアであることと、非制限用法の "which" が指すものは文頭の "the database" よりも直前の "the cookie-based default" であるほうが自然であることから、機密情報の扱いに関する記述を修正する提案をいたします。