### PR TITLE
誤字修正の提案

### DIFF
--- a/guides/source/ja/rails_application_templates.md
+++ b/guides/source/ja/rails_application_templates.md
@@ -87,7 +87,7 @@ end
 add_source "http://code.whytheluckystiff.net"
 ```
 
-ブロックを1つ渡すと、ブロック内のgemエントリがそのソースのグロープにラップされます。
+ブロックを1つ渡すと、ブロック内のgemエントリがそのソースのグループにラップされます。
 
 ```ruby
 add_source "http://gems.github.com/" do


### PR DESCRIPTION
G:90 `グロープ` → `グループ` ではないでしょうか。