### PR TITLE
原著と合わせてデフォルトでinstallされるgemから`uglifier`と`coffee-rails`を削除しました。

### DIFF
--- a/guides/source/ja/asset_pipeline.md
+++ b/guides/source/ja/asset_pipeline.md
@@ -26,15 +26,13 @@
 rails new appname --skip-sprockets
 ```
 
-Railsでは`sass-rails`、`coffee-rails`、`uglifier` gemが自動的にGemfileに追加されます。Sprocketsはアセット圧縮の際にこれらのgemを使用します。
+Railsでは`sass-rails` gemが自動的にGemfileに追加されます。Sprocketsはアセット圧縮の際にこのgemを使用します。
 
 ```ruby
 gem 'sass-rails'
-gem 'uglifier'
-gem 'coffee-rails'
 ```
 
-`--skip-sprockets`オプションを使用すると、Railsで`sass-rails`と`uglifier`がGemfileに追加されなくなります。アセットパイプラインを後から有効にしたい場合は、これらのgemもGemfileに追加する必要があります。同様に、アプリケーション新規作成時に`--skip-sprockets`オプションを指定すると`config/application.rb`ファイルの記述内容がデフォルトから若干異なります。具体的にはsprocket railtieで必要となる記述がコメントアウトされます。アセットパイプラインを手動で有効にする場合は、これらのコメントアウトも解除する必要があります。
+`--skip-sprockets`オプションを使用すると、Railsで`sass-rails`がGemfileに追加されなくなります。アセットパイプラインを後から有効にしたい場合は、このgemもGemfileに追加する必要があります。同様に、アプリケーション新規作成時に`--skip-sprockets`オプションを指定すると`config/application.rb`ファイルの記述内容がデフォルトから若干異なります。具体的にはsprocket railtieで必要となる記述がコメントアウトされます。アセットパイプラインを手動で有効にする場合は、これらのコメントアウトも解除する必要があります。
 
 ```ruby
 # require "sprockets/railtie"


### PR DESCRIPTION
アセットパイプラインのドキュメントにて、原著側で`uglifier`と`coffee-rails`がデフォルトでinstallされる旨の記述が削除されていたので同様に削除しました。

> Rails automatically adds the `sass-rails` gem to your `Gemfile`, which is used
> by Sprockets for asset compression:
> ```ruby
> gem 'sass-rails'
> ```
> https://guides.rubyonrails.org/v6.0/asset_pipeline.html#what-is-the-asset-pipeline-questionmark