### PR TITLE
Rails のルーティング ページの脱字を修正

### DIFF
--- a/guides/source/ja/routing.md
+++ b/guides/source/ja/routing.md
@@ -600,7 +600,7 @@ get 'photos/:id/with_user/:user_id', to: 'photos#show'
 クエリ文字列 (訳注: `?パラメータ名=値`の形式でURLの末尾に置かれるパラメータ) で指定されているパラメータもすべて`params`に含まれます。以下のルーティングを例にとってみましょう。
 
 ```ruby
-photos/:id', to: 'photos#show'
+get 'photos/:id', to: 'photos#show'
 ```
 
 ブラウザからのリクエストで`/photos/1?user_id=2`というパスが渡されると、`Photos`コントローラの`show`アクションに割り当てられます。このときの`params`は`{ controller: 'photos', action: 'show', id: '1', user_id: '2' }`となります。


### PR DESCRIPTION
Fixed https://github.com/yasslab/railsguides.jp/issues/894
上記のIssue内容でドキュメントを修正しました。

原文は以下の通りでした
https://guides.rubyonrails.org/routing.html#the-query-string

> ![image](https://user-images.githubusercontent.com/44657956/91370295-ed046900-e848-11ea-8a97-3448489416e6.png)
