### PR TITLE
ActiveRecordのconnected_toのdatabaseキーワード引数に関する記述を削除

### DIFF
--- a/guides/source/ja/active_record_multiple_databases.md
+++ b/guides/source/ja/active_record_multiple_databases.md
@@ -191,17 +191,6 @@ end
 
 `connected_to`呼び出しの「ロール」では、そのコネクションハンドラ（またはロール）で接続されたコネクションを探索します。`reading`コネクションハンドラは、`reading`というロール名を持つ`connects_to`を介して接続されたすべてのコネクションを維持します。
 
-他のケースとして、アプリケーションの起動時には必ずしも接続しないが、スロークエリ時や分析時に用いたいデータベースがある場合も考えられます。database.ymlでデータベースを定義した後、`connected_to`にデータベース引数を渡すことで接続できます。
-
-
-```ruby
-ActiveRecord::Base.connected_to(database: { reading_slow: :animals_slow_replica }) do
-  # 遅いreplicaへの接続時に行う処理をここに書く
-end
-```
-
-`connected_to`の`database`引数には、シンボルまたは設定ハッシュを1つ渡します。
-
 ここで注意したいのは、ロールを設定した`connected_to`では、既存のコネクションの探索や切り替えにそのコネクションのspecification名が用いられることです。つまり、`connected_to(role: :nonexistent)`のように不明なロールを渡すと、`ActiveRecord::ConnectionNotEstablished (No connection pool with 'AnimalsBase' found
 for the 'nonexistent' role.)`エラーが発生します。
 


### PR DESCRIPTION
ActiveRecord::Base.connected_toの[databaseキーワード引数は6.1でdeprecated、6.2で削除される予定とドキュメントに書かれており](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionHandling.html#method-i-connected_to)、rails本家のガイドでは既に[当該キーワード引数に関する記述が削除](https://github.com/rails/rails/commit/dfb4c1114baa2a8b196b33a1cddb303bb49c7a83#diff-bbdf053688d2be0934e6776908173105)されているため、その削除を反映します。

複数DBの使用に関する翻訳が https://github.com/yasslab/railsguides.jp/pull/848 と https://github.com/yasslab/railsguides.jp/pull/849 によって guides/source/ja/active_record_multiple_database.md と guides/source/ja/active_record_multiple_databases.md に分裂してしまっていてどちらを編集するか迷いましたが、目次では後者にリンクが張られているようなので一旦後者のみを編集しています。