### PR TITLE
`config.active_storage.queues.purge`の説明のtypoを修正

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -769,7 +769,7 @@ text/javascript image/svg+xml application/postscript application/x-shockwave-fla
   config.active_job.queue = :low_priority
   ```
 
-* `config.active_storage.queues.purge`: purgeジョブに用いるActive Jobキューをシンボルで指定します。このオプションが`nil`の場合、解析ジョブはデフォルトのActive Jobキューに送信されます（`config.active_job.default_queue_name`を参照）。
+* `config.active_storage.queues.purge`: purgeジョブに用いるActive Jobキューをシンボルで指定します。このオプションが`nil`の場合、purgeジョブはデフォルトのActive Jobキューに送信されます（`config.active_job.default_queue_name`を参照）。
 
   ```ruby
   config.active_storage.queues.purge = :low_priority


### PR DESCRIPTION
直上で解説している `config.active_storage.queues.analysis` の文章に引きづられているようです。
`purge` の説明なので、ここで説明している対象のジョブは`purge`だと思います。