### PR TITLE
『電子書籍版はコチラから』のリンク先が /undefined にならない様にしたい

### DIFF
--- a/guides/assets/javascripts/guides.js
+++ b/guides/assets/javascripts/guides.js
@@ -51,15 +51,3 @@ var guidesIndex = {
     window.location = url;
   }
 };
-
-// Link to 特設ページ
-jQuery('.ebook-button').click(function() {
-  window.location=$(this).find("a").attr("href");
-  return false;
-});
-
-// Link to Gumroad
-jQuery('.gumroad-button').click(function() {
-  window.location=$(this).find("a").attr("href");
-  return false;
-});


### PR DESCRIPTION
🎫 https://github.com/yasslab/railsguides.jp_web/issues/1047

## やりたいこと

『電子書籍版はコチラから』ボタンのリンク先が undefined になり、リダレクト先がないとエラーになるので、意図した動作の妨げになる部分を削除したい


<img width="566" alt="image" src="https://user-images.githubusercontent.com/6015450/94385507-58ab6000-0180-11eb-9170-ee2bf59a003f.png">

