### PR TITLE
Fix typos in active_record_postgresql.md

### DIFF
--- a/guides/source/ja/active_record_postgresql.md
+++ b/guides/source/ja/active_record_postgresql.md
@@ -217,7 +217,7 @@ contact.address = "(Paris,Rue Basse)"
 contact.save!
 ```
 
-### 列挙型（enumrated type）
+### 列挙型（enumerated type）
 
 * [型の定義](https://www.postgresql.jp/document/current/html/datatype-enum.html)
 

--- a/guides/source/ja/active_record_postgresql.md
+++ b/guides/source/ja/active_record_postgresql.md
@@ -221,7 +221,7 @@ contact.save!
 
 * [型の定義](https://www.postgresql.jp/document/current/html/datatype-enum.html)
 
-現時点では列挙型に特化したサポートはありません。複合型は、通常のテキストカラムにマッピングされます。
+現時点では列挙型に特化したサポートはありません。列挙型は、通常のテキストカラムにマッピングされます。
 
 ```ruby
 # db/migrate/20131220144913_create_articles.rb


### PR DESCRIPTION
`active_record_postgresql.md`の列挙型のドキュメントで、小さいtypoを2つ見つけたので修正しました。


1つは、「列挙型」と書かれるべきところに「複合型」と書かれてしまっていました。
https://github.com/yasslab/railsguides.jp/commit/2021152fb166747cf9b506553a44123c6b4da569

対応する原文を読むと「They are mapped as normal text columns:」となっています。
https://guides.rubyonrails.org/active_record_postgresql.html#enumerated-types
ところが複合型に関するところでも、原文は完全に同じ「They are mapped to normal text columns:」という文になっています。

そのため、複合型のこの文を先に訳した後、同じ文である列挙型のところにコピペしてきてしまって、結果として"複合型"という単語が列挙型のドキュメントに混ざってしまったのではないかなと予想しています。



---


もう1つは単純なたいぽで、enumeratedがenumratedになってしまっていました(enumの後にeが足りない)。
これはエディタのスペルチェッカに引っかかっていて気が付きました。
原文でも「Enumerated Types」というタイトルになっているので、こちらのスペルが正しそうです。