### PR TITLE
モバイル表示時の目次左右の余白を修正

### DIFF
--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -392,7 +392,7 @@ body {
     position: static;
     width: inherit;
     margin-left: -1em;
-    margin-right: 0;
+    margin-right: -1em;
     padding-right: 1.25em;
   }
 }


### PR DESCRIPTION
画面幅が狭いときに目次の横に余白ができてしまう問題を修正しました。
## Before
![image](https://user-images.githubusercontent.com/31533303/99021646-756eec00-25a4-11eb-9637-bcbd7155e1a3.png)

## After
![image](https://user-images.githubusercontent.com/31533303/99021663-80298100-25a4-11eb-807f-c33ed3a9b86e.png)
