### PR TITLE
スマホ表示時の表の見た目を修正

### DIFF
--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -1224,3 +1224,8 @@ code {
 	opacity: 1;
 	transition: opacity 300ms;
 }
+@media only screen and (max-width: 767px) {
+  .pinned table th, .pinned table td, table.responsive {
+    code{ white-space: nowrap; }
+  }
+}


### PR DESCRIPTION
close https://github.com/yasslab/railsguides.jp_web/issues/1045
1行に収めることで「モバイル表示だとテーブルの文字がずれる」問題を修正しました。
![image](https://user-images.githubusercontent.com/31533303/99024866-d8fc1800-25aa-11eb-9fd2-805a164f4c67.png)
