### PR TITLE
正しいファイル名の main.scss を読み込むように変更したい

### DIFF
--- a/guides/assets/stylesheets/style.css
+++ b/guides/assets/stylesheets/style.css
@@ -10,5 +10,5 @@ Import advanced style sheet
 */
 
 @import url("reset.css");
-@import url("main.css");
+@import url("main.scss");
 @import url("carbonads.css");


### PR DESCRIPTION
## やりたいこと

生成した HTML を Docset などに入れた際にデザインが反映されないので、正しいファイル名のスタイルを参照するようにしたい