### PR TITLE
Revert "Merge pull request #998 from yasslab/fix-typo-ext-css"

### DIFF
--- a/guides/assets/stylesheets/style.css
+++ b/guides/assets/stylesheets/style.css
@@ -10,5 +10,5 @@ Import advanced style sheet
 */
 
 @import url("reset.css");
-@import url("main.scss");
+@import url("main.css");
 @import url("carbonads.css");


### PR DESCRIPTION
This reverts commit 285879ede31777a2fc6bcff2f602aaaa0371e592, reversing
changes made to 823f0d006fce9afcef52c59fda246f98d69aa845.

## Revert したい理由

`main.css` に変更した影響で表示のズレが起こる事がわかった。
Jekyll で `precompile` を行った際に `.css` に変換されるので、スタイルシートで `.scss` をファイル指定する必要はない。