### PR TITLE
emailがリンクになっているので、コードで表すように変更しました

### DIFF
--- a/guides/source/ja/getting_started.md
+++ b/guides/source/ja/getting_started.md
@@ -428,7 +428,7 @@ end
 
 ここで`render`メソッドは非常に単純なハッシュを引数に取ります。ハッシュのキーは`:plain`、ハッシュの値は`params[:article].inspect`です。`params`メソッドは、フォームから送信されてきたパラメータ (つまりフォームのフィールド) を表すオブジェクトです。`params`メソッドは`ActionController::Parameters`オブジェクトを返します。文字列またはシンボルを使って、このオブジェクトのハッシュのキーを指定できます。今回の場合、必要なのはフォームの値のうちの1つだけです。
 
-TIP: `params`メソッドは今後多用することになりますので、しっかり理解しておいてください。**http://www.example.com/?username=dhh&email=dhh@email.com**というURLで説明すると、`params[:username]`の値が "dhh"、`params[:email]`の値が "dhh@email.com" となります。
+TIP: `params`メソッドは今後多用することになりますので、しっかり理解しておいてください。**http://www.example.com/?username=dhh&email=dhh@email.com**というURLで説明すると、`params[:username]`の値が "`dhh`"、`params[:email]`の値が "`dhh@email.com`" となります。
 
 フォームを再送信してみると、今度は以下が表示されました。
 


### PR DESCRIPTION
## 背景
- `dhh@email.com`という文字列がリンクになっている
  <img width="649" alt="スクリーンショット 2020-12-25 8 40 13" src="https://user-images.githubusercontent.com/1221303/103111129-ecf86680-468c-11eb-8312-22bba7b3fc59.png">
- 文字列で表示したい

## やったこと
- [x] `dhh`, `dhh@email.com` をコードとして表示した
  <img width="640" alt="スクリーンショット 2020-12-25 8 45 52" src="https://user-images.githubusercontent.com/1221303/103111191-a0615b00-468d-11eb-865f-cd246ec383d5.png">
