### PR TITLE
文章が変になっていた部分を修正

### DIFF
--- a/guides/source/ja/i18n.md
+++ b/guides/source/ja/i18n.md
@@ -183,7 +183,7 @@ end
 #   127.0.0.1 application.com
 #   127.0.0.1 application.it
 #   127.0.0.1 application.pl
-# /etc/hosts上のように記述する必要がある
+# /etc/hostsファイルに上のように記述する必要がある
 def extract_locale_from_tld
   parsed_locale = request.host.split('.').last
   I18n.available_locales.map(&:to_s).include?(parsed_locale) ? parsed_locale : nil


### PR DESCRIPTION
「/etc/hosts上のように記述する必要がある」では分かりづらいので、一つ下のコードブロック内の説明「/etc/hostsファイルに上のように記述する必要がある」に合わせました。