### PR TITLE
コードの記述を統一した

### DIFF
--- a/guides/source/ja/upgrading_ruby_on_rails.md
+++ b/guides/source/ja/upgrading_ruby_on_rails.md
@@ -1200,13 +1200,9 @@ class FooBar
     { foo: 'bar' }
   end
 end
-```
 
-```irb
-irb> FooBar.new.to_json
-=> "{\"foo\":\"bar\"}"
-irb> JSON.generate(FooBar.new, quirks_mode: true)
-=> "\"#<FooBar:0x007fa80a481610>\""
+FooBar.new.to_json # => "{\"foo\":\"bar\"}"
+JSON.generate(FooBar.new, quirks_mode: true) # => "\"#<FooBar:0x007fa80a481610>\""
 ```
 
 #### 新しいJSONエンコーダ


### PR DESCRIPTION
## 背景
- 日本語のRailsチュートリアルでは irb の記述の仕方ではなく、rbのコード内に記述するに統一されてる

## やったこと
- [x] 記述の仕方を統一した
