### PR TITLE
fix typo

### DIFF
--- a/guides/source/ja/active_storage_overview.md
+++ b/guides/source/ja/active_storage_overview.md
@@ -229,13 +229,13 @@ end
 既存のuserにavatarを添付するには`avatar.attach`を呼び出します。
 
 ```ruby
-Current.user.avatar.attach(params[:avatar])
+user.avatar.attach(params[:avatar])
 ```
 
 `avatar.attached?`で特定のuserがavatarを持っているかどうかを調べられます。
 
 ```ruby
-Current.user.avatar.attached?
+user.avatar.attached?
 ```
 
 ### `has_many_attached`


### PR DESCRIPTION
多分、不要だと思います
https://guides.rubyonrails.org/active_storage_overview.html#has-one-attached にも記載されていませんでした。
(`Current` どこから来たんだろう...🤔