### PR TITLE
Fix command example format

### DIFF
--- a/guides/source/ja/api_documentation_guidelines.md
+++ b/guides/source/ja/api_documentation_guidelines.md
@@ -17,7 +17,7 @@ RDoc
 [Rails API ドキュメント](http://api.rubyonrails.org)は[RDoc](https://ruby.github.io/rdoc/)で生成されます。生成するには、Railsのルートディレクトリで`bundle install`を実行してから、以下を実行します。
 
 ```bash
-  bundle exec rake rdoc
+$ bundle exec rake rdoc
 ```
 
 生成されたHTMLファイルは./doc/rdocディレクトリに置かれます。


### PR DESCRIPTION
「API ドキュメント作成ガイドライン」のコマンド実行のコードのフォーマットがおかしかったので修正します。

不要な空白が入っていて、表示がおかしくなっていました。


before

![210502005842](https://user-images.githubusercontent.com/4361134/116787869-9212c800-aae1-11eb-8760-b551b044ecf3.png)


after

![210502005858](https://user-images.githubusercontent.com/4361134/116787874-9c34c680-aae1-11eb-850b-45f02bd27467.png)


なお英語の原文でもこのPRの修正のように、`$`が先頭に書かれているようです。
https://guides.rubyonrails.org/api_documentation_guidelines.html#rdoc