### PR TITLE
Articleの詳細画面で出力するカラム名のバグを修正

### DIFF
--- a/guides/source/ja/getting_started.md
+++ b/guides/source/ja/getting_started.md
@@ -1334,8 +1334,8 @@ end
 </p>
 
 <p>
-  <strong>Text:</strong>
-  <%= @article.text %>
+  <strong>Body:</strong>
+  <%= @article.body %>
 </p>
 
 <h2>Comments</h2>


### PR DESCRIPTION
### 記事の内容を表示させる部分でカラム名の間違いを発見

誤: `@article.text`
正: `@article.body`
