### PR TITLE
iOS Safari表示時のフォントサイズを修正

### DIFF
--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -150,6 +150,8 @@ table {
   border: 2px solid #CCC;
   background: #FFF;
   border-collapse: collapse;
+  text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
   th, td {
     padding: 0.25em 1em;
     border: 1px solid #CCC;


### PR DESCRIPTION
close https://github.com/yasslab/railsguides.jp_web/issues/1175
画像のように、表のフォントがずれてしまう問題があったので修正しました。
![image](https://user-images.githubusercontent.com/31533303/117235606-0347d780-ae62-11eb-9507-1945cf20ff3c.png)
