### PR TITLE
表の改行のズレを修正

### DIFF
--- a/guides/source/ja/getting_started.md
+++ b/guides/source/ja/getting_started.md
@@ -153,7 +153,7 @@ bin/ | ここにはアプリケーションを起動/アップデート/デプ�
 config/ | アプリケーションの設定ファイル（ルーティング、データベースなど）がここに置かれます。詳しくは[Rails アプリケーションを設定する](configuring.html) を参照してください。
 config.ru | アプリケーションの起動に必要となる、Rackベースのサーバー用のRack設定ファイルです。Rackについて詳しくは、[RackのWebサイト](https://rack.github.io/)を参照してください。
 db/ | 現時点のデータベーススキーマと、データベースマイグレーションファイルが置かれます。
-Gemfile<br>Gemfile.lock | これらのファイルは、Railsアプリケーションで必要となるgemの依存関係を記述します。この2つのファイルはBundler gemで使われます。Bundlerについて詳しくは[BundlerのWebサイト](https://bundler.io/)を参照してください。
+Gemfile<br>Gemfile.lock | これらのファイルは、Railsアプリケーションで必要となるgemの依存関係を記述します。<br>この2つのファイルはBundler gemで使われます。Bundlerについて詳しくは[BundlerのWebサイト](https://bundler.io/)を参照してください。
 lib/ | アプリケーションで使う拡張モジュールが置かれます。
 log/ | アプリケーションのログファイルが置かれます。
 package.json | Railsアプリケーションで必要なnpm依存関係をこのファイルで指定できます。このファイルはYarnで使われます。Yarnについて詳しくは、[YarnのWebサイト](https://yarnpkg.com/lang/en/)を参照してください。


### PR DESCRIPTION
close https://github.com/yasslab/railsguides.jp_web/issues/1178

### やったこと
説明文にも改行を追加することでズレを抑えました👀

Before
<img width="306" alt="スクリーンショット 2021-05-07 15 45 28" src="https://user-images.githubusercontent.com/48109243/117408691-40d45f80-af4b-11eb-9fea-57ce6392d001.png">


After

<img width="310" alt="スクリーンショット 2021-05-07 15 42 49" src="https://user-images.githubusercontent.com/48109243/117408424-e20ee600-af4a-11eb-9b23-b385c881b074.png">
