### PR TITLE
8.1「パーシャルコレクションをレンダリングする」のコードブロックの修正

### DIFF
--- a/guides/source/ja/getting_started.md
+++ b/guides/source/ja/getting_started.md
@@ -1266,18 +1266,17 @@ end
 最初に、特定記事のコメントをすべて表示する部分を切り出してコメントパーシャルを作成しましょう。`app/views/comments/_comment.html.erb`というファイルを作成し、以下のコードを入力します。
 
 ```html+erb
-<%= form_with model: [ @article, @article.comments.build ] do |form| %>
+<% @article.comments.each do |comment| %>
   <p>
-    <%= form.label :commenter %><br>
-    <%= form.text_field :commenter %>
+    <strong>Commenter:</strong>
+    <%= comment.commenter %>
   </p>
+
   <p>
-    <%= form.label :body %><br>
-    <%= form.text_area :body %>
+    <strong>Comment:</strong>
+    <%= comment.body %>
   </p>
-  <p>
-    <%= form.submit %>
-  </p>
+
 <% end %>
 ```
 


### PR DESCRIPTION
8.1「パーシャルコレクションをレンダリングする」の1つ目のコードブロックが，commentを表示するものでは無かったため，修正を行いました．
元版では`<% @article.comments.each do |comment| %>`と`<% end %>`が省略されていたため，追加してファイル全体のコードとして記述しました．