### PR TITLE
引数を伴う場合スコープではなくクラスメソッドを推奨する説明を削除

### DIFF
--- a/guides/source/ja/active_record_querying.md
+++ b/guides/source/ja/active_record_querying.md
@@ -1319,7 +1319,7 @@ class Article < ApplicationRecord
 end
 ```
 
-したがって、スコープで引数を使用するのであれば、クラスメソッドとして定義する方が推奨されます。クラスメソッドにした場合でも、関連オブジェクトからアクセス可能です。
+クラスメソッドにした場合でも、関連オブジェクトからアクセス可能です。
 
 ```ruby
 category.articles.created_before(time)

--- a/guides/source/ja/active_record_querying.md
+++ b/guides/source/ja/active_record_querying.md
@@ -1319,7 +1319,7 @@ class Article < ApplicationRecord
 end
 ```
 
-クラスメソッドにした場合でも、関連オブジェクトからアクセス可能です。
+スコープとして定義したメソッドは、関連オブジェクトからアクセス可能です。
 
 ```ruby
 category.articles.created_before(time)


### PR DESCRIPTION
こんにちは！Railsガイドの運用をいつもありがとうございます:sparkles:

https://github.com/rails/rails/commit/3dbe9a50d764679ce15a3ccb005edd3d5a494114 のコミットで、Rails 6.1 以降、引数を渡したい場合はスコープではなくクラスメソッドとして定義することを推奨する説明が削除されていました。
元々クラスメソッドの方が推奨されていた理由は明確にはなさそうなので、日本語版の方でも削除したほうが良いのではないかと思います。また、少々後続の文の訳を変更してみました。いかがでしょうか。
