### PR TITLE
デフォルトの description を読み込ま無いように削除したい

### DIFF
--- a/guides/source/ja/layout.html.erb
+++ b/guides/source/ja/layout.html.erb
@@ -3,7 +3,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="ja" lang="ja">
   <head>
 
-    <% provide(:desc, "Railsガイドは Ruby on Rails Guides に基づいた大型リファレンスガイドです。Rails開発の生産性を高めたいときや、Railsの各機能を体系的に学びたいときに役立ちます。") %>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
     <meta name="viewport"    content="width=device-width, initial-scale=1"/>
     <meta name="description" content="<%= yield(:desc) %>" />


### PR DESCRIPTION
## やりたいこと

デフォルトの description が呼び込まれて、適切なページの description を反映できなくなっているのを防ぎたい。

