### PR TITLE
ActiveRecordにミックスインされるクラス名を修正します

### DIFF
--- a/guides/source/ja/active_job_basics.md
+++ b/guides/source/ja/active_job_basics.md
@@ -338,7 +338,7 @@ class TrashableCleanupJob  < ApplicationJob
 end
 ```
 
-上のコードは、`ActiveModel::GlobalIdentification`をミックスインするすべてのクラスで動作します。このモジュールはActive Recordクラスにデフォルトでミックスインされます。
+上のコードは、`GlobalID::Identification`をミックスインするすべてのクラスで動作します。このモジュールはActive Recordクラスにデフォルトでミックスインされます。
 
 ### シリアライザ
 


### PR DESCRIPTION
Rails 4.2より過去の記述がそのままになっていました。 ミックスインされるクラスは `GlobalID::Identification` が適切かと思います。

rails/rails で対応しているPRはこちらです。
[correct GlobalID mixin name in the guides by cmoylan · Pull Request #17432 · rails/rails](https://github.com/rails/rails/pull/17432)