### PR TITLE
comment_paramsの記述漏れを修正

### DIFF
--- a/guides/source/ja/getting_started.md
+++ b/guides/source/ja/getting_started.md
@@ -1651,7 +1651,7 @@ class CommentsController < ApplicationController
 
   private
     def comment_params
-      params.require(:comment).permit(:commenter, :body)
+      params.require(:comment).permit(:commenter, :body, :status)
     end
 end
 ```


### PR DESCRIPTION
該当コードの前項で、`comment_params`に追加している`:status`が抜けているようなので、追加しました。