### PR TITLE
typo 修正 Artivle => Article

### DIFF
--- a/guides/source/ja/getting_started.md
+++ b/guides/source/ja/getting_started.md
@@ -413,7 +413,7 @@ Loading development environment (Rails 6.0.2.1)
 irb(main):001:0>
 ```
 
-このプロンプトで、先ほど作成した`Artivle`オブジェクトを以下のように初期化できます。
+このプロンプトで、先ほど作成した`Article`オブジェクトを以下のように初期化できます。
 
 ```
 irb> article = Article.new(title: "Hello Rails", body: "I am on Rails!")


### PR DESCRIPTION
## やったこと

- `Rails をはじめよう` にあった typo の修正
  - Artivle => Article
  - 原文(英語)も確認しましたが、原文(英語)の方は問題ありませんでした 🙏 