### PR TITLE
Fix command example

### DIFF
--- a/guides/source/ja/getting_started.md
+++ b/guides/source/ja/getting_started.md
@@ -227,7 +227,7 @@ $ cd blog
 先ほど作成したRailsアプリケーションは、既に実行可能な状態になっています。Webアプリケーションを開発用のPCで実際に動かしてこのことを確かめてみましょう。`blog`ディレクトリに移動し、以下のコマンドを実行します。
 
 ```bash
-$ rails server
+$ bin/rails server
 ```
 
 TIP: Windowsをお使いの場合は、`bin`フォルダの下にあるスクリプトをRubyインタープリタに直接渡さなければなりません（例: `ruby bin\rails server`）
@@ -1192,7 +1192,7 @@ TIP: ルーティングについて詳しくは[Railsのルーティング](rout
 モデルを手作りしたのですから、それに合ったコントローラも作ってみたくなります。それでは、再びこれまでと同様にジェネレータを使ってみましょう。
 
 ```bash
-$ rails generate controller Comments
+$ bin/rails generate controller Comments
 ```
 
 上のコマンドを実行すると、4つのファイルと1つの空ディレクトリが作成されます。


### PR DESCRIPTION
「Rails をはじめよう」のコマンド実行のコードの一部が `bin/rails` ではなく `rails` になっていたため修正します。

なお、英語の原文でも「4 Hello, Rails!」以降は、`bin/rails`で統一されているようです。
https://guides.rubyonrails.org/getting_started.html#hello-rails-bang

日本語版（修正前）
![スクリーンショット 2021-09-05 17 08 58](https://user-images.githubusercontent.com/51506307/132120941-6a1244c6-167e-4720-9b41-e6ac058e9f84.png)
英語版
![スクリーンショット 2021-09-05 17 20 11](https://user-images.githubusercontent.com/51506307/132120954-3267b0da-95dc-4fd1-b4ab-f94cd4904cfa.png)

日本語版（修正前）
![スクリーンショット 2021-09-05 17 08 48](https://user-images.githubusercontent.com/51506307/132120959-d2cece7e-590a-47b9-8f0e-1c42f0d8667e.png)
英語版
![スクリーンショット 2021-09-05 17 09 06](https://user-images.githubusercontent.com/51506307/132120966-c352ed22-93cf-4c42-bc50-49e169edd9a2.png)
