### PR TITLE
開発環境でのSTI用のEager Loadスクリプトを最新の追従

### DIFF
--- a/guides/source/ja/autoloading_and_reloading_constants.md
+++ b/guides/source/ja/autoloading_and_reloading_constants.md
@@ -227,11 +227,11 @@ module StiPreload
       def preload_sti
         types_in_db = \
           base_class.
+            unscoped.
             select(inheritance_column).
             distinct.
             pluck(inheritance_column).
-            compact.
-            each(&:constantize)
+            compact
 
         types_in_db.each do |type|
           logger.debug("Preloading STI type #{type}")


### PR DESCRIPTION
読んでいて `constantize` が重複しているなと思って  [原文](https://github.com/yasslab/railsguides.jp/blob/master/guides/source/autoloading_and_reloading_constants.md#single-table-inheritance) を読むと以下の点が更新されていたので追従しました

- unscopeの追加
- constantizeが重複していたのを削除