### PR TITLE
APIのリンク書き換えを https も対応するように修正

### DIFF
--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -17,7 +17,7 @@ HTML
       end
 
       def link(url, title, content)
-        if url.start_with?("http://api.rubyonrails.org")
+        if /(^https|^http):\/\/api.rubyonrails.org/.match?(url)
           %(<a href="#{api_link(url)}">#{content}</a>)
         elsif title
           %(<a href="#{url}" title="#{title}">#{content}</a>)
@@ -115,7 +115,7 @@ HTML
         end
 
         def api_link(url)
-          if url =~ %r{http://api\.rubyonrails\.org/v\d+\.}
+          if url =~ %r{(^https|^http)://api\.rubyonrails\.org/v\d+\.}
             url
           elsif edge
             url.sub("api", "edgeapi")


### PR DESCRIPTION
関連: #1079 

## 背景
- api_link メソッドは、`http://api.rubyonrails.org/classes/ActionController.html` を `http://api.rubyonrails.org/v6.0/classes/ActionController.html` に置換するができる
- `https`の時は書き換えることができていない
- `master`ブランチにも導入したい

## やったこと
- [x] `https` の場合も置換するように修正

## 確かめ方
1. 以下のコマンドを実行する
  ```
bundle exec rake assets:precompile RAILS_VERSION=v6.1`
  ```
1. `bundle exec jekyll server` でサーバーを起動
1.  http://localhost:4000/action_controller_overview.html#%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89%E3%81%A8%E3%82%A2%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3 にある `APIドキュメント`URLが https://api.rubyonrails.org/v6.1/classes/ActionController.html であることを確認する