### PR TITLE
after_touch のメッセージ内容と表示順序を修正

### DIFF
--- a/guides/source/ja/active_record_callbacks.md
+++ b/guides/source/ja/active_record_callbacks.md
@@ -173,7 +173,7 @@ end
 class Employee < ApplicationRecord
   belongs_to :company, touch: true
   after_touch do
-    puts 'Employeeモデルにtouchされました'
+    puts 'Employeeがtouchされました'
   end
 end
 
@@ -192,8 +192,8 @@ end
 
 # @employee.company.touchをトリガーする
 >> @employee.touch
-Employee/Companyがtouchされました
 Employeeがtouchされました
+Employee/Companyがtouchされました
 => true
 ```
 


### PR DESCRIPTION
`afer_touch` の例が間違っていると思うので修正しました。

- `puts` の引数とプリントされてるメッセージ文言が違うので、 `Employeeがtouchされました` に統一しました。
- `Employee` と `Employee/Company` メッセージのプリント順序が逆になっているため、修正しました。

原文: https://guides.rubyonrails.org/active_record_callbacks.html#after-touch

> irb> @employee.touch # triggers @employee.company.touch
> An Employee was touched
> Employee/Company was touched

(一応手元で実際に試し、原文のように `Employee` の `after_touch` が先に実行される事を確認しました)