### PR TITLE
Fix typo from Sprocket to Sprockets

### DIFF
--- a/guides/source/ja/asset_pipeline.md
+++ b/guides/source/ja/asset_pipeline.md
@@ -32,7 +32,7 @@ Railsでは`sass-rails` gemが自動的にGemfileに追加されます。Sprocke
 gem 'sass-rails'
 ```
 
-`--skip-sprockets`オプションを使用すると、Railsで`sass-rails`がGemfileに追加されなくなります。アセットパイプラインを後から有効にしたい場合は、このgemもGemfileに追加する必要があります。同様に、アプリケーション新規作成時に`--skip-sprockets`オプションを指定すると`config/application.rb`ファイルの記述内容がデフォルトから若干異なります。具体的にはsprocket railtieで必要となる記述がコメントアウトされます。アセットパイプラインを手動で有効にする場合は、これらのコメントアウトも解除する必要があります。
+`--skip-sprockets`オプションを使用すると、Railsで`sass-rails`がGemfileに追加されなくなります。アセットパイプラインを後から有効にしたい場合は、このgemもGemfileに追加する必要があります。同様に、アプリケーション新規作成時に`--skip-sprockets`オプションを指定すると`config/application.rb`ファイルの記述内容がデフォルトから若干異なります。具体的にはsprockets railtieで必要となる記述がコメントアウトされます。アセットパイプラインを手動で有効にする場合は、これらのコメントアウトも解除する必要があります。
 
 ```ruby
 # require "sprockets/railtie"

--- a/guides/source/ja/webpacker.md
+++ b/guides/source/ja/webpacker.md
@@ -5,7 +5,7 @@ Webpacker の概要
 
 このガイドの内容:
 
-* Webpackerとは何か、およびSprocketと異なっている理由
+* Webpackerとは何か、およびSprocketsと異なっている理由
 * Webpackerのインストール方法、および選択したフレームワークとの統合方法
 * JavaScriptアセットをWebpackerで管理する方法
 * CSSアセットをWebpackerで管理する方法


### PR DESCRIPTION
Sprockets について、一部の箇所の表記が Sprocket と単数形になっていたため修正しました。