### PR TITLE
「3.13 Active Supportを設定する」の項目を原著に合わせて追加しました。

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -671,9 +671,15 @@ Active Supportにもいくつかの設定オプションがあります。
 
 * `ActiveSupport::Deprecation.behavior`: `config.active_support.deprecation`に対するもう一つのセッターであり、Railsの非推奨警告メッセージの表示方法を設定します。
 
+* `ActiveSupport::Deprecation.disallowed_behavior`: `config.active_support.disallowed_deprecation`に対するもう一つのセッターであり、Railsの許可しない非推奨警告メッセージの表示方法を設定します。
+
+* `ActiveSupport::Deprecation.disallowed_warnings`: `config.active_support.disallowed_deprecation_warnings`に対するもう一つのセッターであり、アプリケーションで許可しない非推奨の警告を設定するものです。例えば特定の非推奨の警告を例外として扱うことが出来ます。
+
 * `ActiveSupport::Deprecation.silence`: ブロックを1つ引数に取り、すべての非推奨警告メッセージを抑制します。
 
 * `ActiveSupport::Deprecation.silenced`: 非推奨警告メッセージを表示するかどうかを指定します。デフォルトは`false`です。
+
+* `ActiveSupport.utc_to_local_returns_utc_offset_times`: `ActiveSupport::TimeZone.utc_to_local`で、UTCオフセットを考慮したUTC時間ではなく、UTCオフセットを考慮したローカル時間を返すように設定します。
 
 ### Active Jobを設定する
 


### PR DESCRIPTION
原著のConfiguring Rails ApplicationsのConfiguring Active Supportに記載されている以下の項目の翻訳を追加してみました。
いかがでしょうか。

> * `ActiveSupport::Deprecation.disallowed_behavior` alternative setter to `config.active_support.disallowed_deprecation` which configures the behavior of disallowed deprecation warnings for Rails.
> * `ActiveSupport::Deprecation.disallowed_warnings` alternative setter to `config.active_support.disallowed_deprecation_warnings` which configures deprecation warnings that the Application considers disallowed. This allows, for example, specific deprecations to be treated as hard failures.
> * `ActiveSupport.utc_to_local_returns_utc_offset_times` configures `ActiveSupport::TimeZone.utc_to_local` to return a time with a UTC offset instead of a UTC time incorporating that offset.
> 
> https://guides.rubyonrails.org/configuring.html#configuring-active-support