### PR TITLE
`Active Model の 基礎` の `1.10 Lintテスト` のサンプルコードにシンタックスハイライトが当たるよう修正

### DIFF
--- a/guides/source/ja/active_model_basics.md
+++ b/guides/source/ja/active_model_basics.md
@@ -382,6 +382,7 @@ Person.human_attribute_name('name') # => "Nome"
 `ActiveModel::Lint::Tests`を用いて、オブジェクトがActive Model APIに準拠しているかどうかをテストできます。
 
 * `app/models/person.rb`
+
   ```ruby
   class Person
     include ActiveModel::Model
@@ -389,6 +390,7 @@ Person.human_attribute_name('name') # => "Nome"
   ```
 
 * `test/models/person_test.rb`
+
   ```ruby
   require 'test_helper'
 


### PR DESCRIPTION
- list と コードブロックの間に改行が入っていなくて表示がおかしくなっていた
- コードブロック部分のインデントは原語版から既に入っているためそのままにしています

## Before

![before](https://user-images.githubusercontent.com/7955461/139560728-e41a4bf6-f71c-445a-8907-7e2628ba674f.png)

## After

![after](https://user-images.githubusercontent.com/7955461/139560708-1df8c5ee-ac98-4962-a452-c2d42b9b9d38.png)
