### PR TITLE
Zeitwerkアップグレードガイド

### DIFF
--- a/guides/source/classic_to_zeitwerk_howto.md
+++ b/guides/source/classic_to_zeitwerk_howto.md
@@ -1,0 +1,398 @@
+**DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**
+
+Classic to Zeitwerk HOWTO
+=========================
+
+This guide documents how to migrate Rails applications from `classic` to `zeitwerk` mode.
+
+After reading this guide, you will know:
+
+* What are `classic` and `zeitwerk` modes
+* Why switch from `classic` to `zeitwerk`
+* How to activate `zeitwerk` mode
+* How to verify your application runs in `zeitwerk` mode
+* How to verify your project loads OK in the command line
+* How to verify your project loads OK in the test suite
+* How to address possible edge cases
+* New features in Zeitwerk you can leverage
+
+--------------------------------------------------------------------------------
+
+What are `classic` and `zeitwerk` Modes?
+--------------------------------------------------------
+
+From the very beginning, and up to Rails 5, Rails used an autoloader implemented in Active Support. This autoloader is known as `classic` and is still available in Rails 6.x. Rails 7 does not include this autoloader anymore.
+
+Starting with Rails 6, Rails ships with a new and better way to autoload, which delegates to the [Zeitwerk](https://github.com/fxn/zeitwerk) gem. This is `zeitwerk` mode. By default, applications loading the 6.0 and 6.1 framework defaults run in `zeitwerk` mode, and this is the only mode available in Rails 7.
+
+
+Why Switch from `classic` to `zeitwerk`?
+----------------------------------------
+
+The `classic` autoloader has been extremely useful, but had a number of [issues](https://guides.rubyonrails.org/v6.1/autoloading_and_reloading_constants_classic_mode.html#common-gotchas) that made autoloading a bit tricky and confusing at times. Zeitwerk was developed to address them, among other [motivations](https://github.com/fxn/zeitwerk#motivation).
+
+When upgrading to Rails 6.x, it is highly encouraged to switch to `zeitwerk` mode because `classic` mode is deprecated.
+
+Rails 7 ends the transition period and does not include `classic` mode.
+
+I am Scared
+-----------
+
+Don't :).
+
+Zeitwerk was designed to be as compatible with the classic autoloader as possible. If you have a working application autoloading correctly today, chances are the switch will be easy. Many projects, big and small, have reported really smooth switches.
+
+This guide will help you change the autoloader with confidence.
+
+If for whatever reason you find a situation you don't know how to resolve, don't hesitate to [open an issue in `rails/rails`](https://github.com/rails/rails/issues/new) and tag [`@fxn`](https://github.com/fxn).
+
+
+How to Activate `zeitwerk` Mode
+-------------------------------
+
+### Applications running Rails 5.x or Less
+
+In applications running a Rails version previous to 6.0, `zeitwerk` mode is not available. You need to be at least in Rails 6.0.
+
+### Applications running Rails 6.x
+
+In applications running Rails 6.x there are two scenarios.
+
+If the application is loading the framework defaults of Rails 6.0 or 6.1 and it is running in `classic` mode, it must be opting out by hand. You have to have something similar to this:
+
+```ruby
+# config/application.rb
+config.load_defaults 6.0
+config.autoloader = :classic # DELETE THIS LINE
+```
+
+As noted, just delete the override, `zeitwerk` mode is the default.
+
+On the other hand, if the application is loading old framework defaults you need to enable `zeitwerk` mode explicitly:
+
+```ruby
+# config/application.rb
+config.load_defaults 5.2
+config.autoloader = :zeitwerk
+```
+
+### Applications Running Rails 7
+
+In Rails 7 there is only `zeitwerk` mode, you do not need to do anything to enable it.
+
+Indeed, the setter `config.autoloader=` does not even exist. If `config/application.rb` has it, please just delete the line.
+
+
+How to Verify The Application Runs in `zeitwerk` Mode?
+------------------------------------------------------
+
+To verify the application is running in `zeitwerk` mode, execute
+
+```
+bin/rails runner 'p Rails.autoloaders.zeitwerk_enabled?'
+```
+
+If that prints `true`, `zeitwerk` mode is enabled.
+
+
+Does my Application Comply with Zeitwerk Conventions?
+-----------------------------------------------------
+
+Once `zeitwerk` mode is enabled, please run:
+
+```
+bin/rails zeitwerk:check
+```
+
+A successful check looks like this:
+
+```
+% bin/rails zeitwerk:check
+Hold on, I am eager loading the application.
+All is good!
+```
+
+There can be additional output depending on the application configuration, but the last "All is good!" is what you are looking for.
+
+If there's any file that does not define the expected constant, the task will tell you. It does so one file at a time, because if it moved on, the failure loading one file could cascade into other failures unrelated to the check we want to run and the error report would be confusing.
+
+If there's one constant reported, fix that particular one and run the task again. Repeat until you get "All is good!".
+
+Take for example:
+
+```
+% bin/rails zeitwerk:check
+Hold on, I am eager loading the application.
+expected file app/models/vat.rb to define constant Vat
+```
+
+VAT is an European tax. The file `app/models/vat.rb` defines `VAT` but the autoloader expects `Vat`, why?
+
+### Acronyms
+
+This is the most common kind of discrepancy you may find, it has to do with acronyms. Let's understand why do we get that error message.
+
+The classic autoloader is able to autoload `VAT` because its input is the name of the missing constant, `VAT`, invokes `underscore` on it, which yields `vat`, and looks for a file called `vat.rb`. It works.
+
+The input of the new autoloader is the file system. Give the file `vat.rb`, Zeitwerk invokes `camelize` on `vat`, which yields `Vat`, and expects the file to define the constant `Vat`. That is what the error message says.
+
+Fixing this is easy, you only need to tell the inflector about this acronym:
+
+```ruby
+# config/initializers/inflections.rb
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "VAT"
+end
+```
+
+Doing so affects how Active Support inflects globally. That may be fine, but if you prefer you can also pass overrides to the inflector used by the autoloader:
+
+```ruby
+# config/initializers/zeitwerk.rb
+Rails.autoloaders.each do |autoloader|
+  autoloader.inflector.inflect("vat" => "VAT")
+end
+```
+
+With that in place, the check passes!
+
+```
+% bin/rails zeitwerk:check
+Hold on, I am eager loading the application.
+All is good!
+```
+
+### Concerns
+
+You can autoload and eager load from a standard structure with `concerns` subdirectories like
+
+```
+app/models
+app/models/concerns
+```
+
+By default, `app/models/concerns` belongs to the autoload paths and therefore it is assumed to be a root directory. So, by default, `app/models/concerns/foo.rb` should define `Foo`, not `Concerns::Foo`.
+
+If your application uses `Concerns` as namespace, you have two options:
+
+1. Remove the `Concerns` namespace from those classes and modules and update client code.
+2. Leave things as they are by removing `app/models/concerns` from the autoload paths:
+
+  ```ruby
+  # config/initializers/zeitwerk.rb
+  ActiveSupport::Dependencies.
+    autoload_paths.
+    delete("#{Rails.root}/app/models/concerns")
+  ```
+
+### Having `app` in the autoload paths
+
+Some projects want something like `app/api/base.rb` to define `API::Base`, and add `app` to the autoload paths to accomplish that.
+
+Since Rails adds all subdirectories of `app` to the autoload paths automatically (with a few exceptions like directories for assets), we have another situation in which there are nested root directories, similar to what happens with `app/models/concerns`. That setup no longer works as is.
+
+However, you can keep that structure, just delete `app/api` from the autoload paths in an initializer:
+
+```ruby
+# config/initializers/zeitwerk.rb
+ActiveSupport::Dependencies.
+  autoload_paths.
+  delete("#{Rails.root}/app/api")
+```
+
+### Autoloaded Constants and Explicit Namespaces
+
+If a namespace is defined in a file, as `Hotel` is here:
+
+```
+app/models/hotel.rb         # Defines Hotel.
+app/models/hotel/pricing.rb # Defines Hotel::Pricing.
+```
+
+the `Hotel` constant has to be set using the `class` or `module` keywords. For example:
+
+```ruby
+class Hotel
+end
+```
+
+is good.
+
+Alternatives like
+
+```ruby
+Hotel = Class.new
+```
+
+or
+
+```ruby
+Hotel = Struct.new
+```
+
+won't work, child objects like `Hotel::Pricing` won't be found.
+
+This restriction only applies to explicit namespaces. Classes and modules not defining a namespace can be defined using those idioms.
+
+### One file, one constant (at the same top-level)
+
+In `classic` mode you could technically define several constants at the same top-level and have them all reloaded. For example, given
+
+```ruby
+# app/models/foo.rb
+
+class Foo
+end
+
+class Bar
+end
+```
+
+while `Bar` could not be autoloaded, autoloading `Foo` would mark `Bar` as autoloaded too.
+
+This is not the case in `zeitwerk` mode, you need to move `Bar` to its own file `bar.rb`. One file, one top-level constant.
+
+This affects only to constants at the same top-level as in the example above. Inner classes and modules are fine. For example, consider
+
+```ruby
+# app/models/foo.rb
+
+class Foo
+  class InnerClass
+  end
+end
+```
+
+If the application reloads `Foo`, it will reload `Foo::InnerClass` too.
+
+### Globs in `config.autoload_paths`
+
+Beware of configurations that use wildcards like
+
+```ruby
+config.autoload_paths += Dir["#{config.root}/extras/**/"]
+```
+
+Every element of `config.autoload_paths` should represent the top-level namespace (`Object`). That won't work.
+
+To fix this, just remove the wildcards:
+
+```ruby
+config.autoload_paths << "#{config.root}/extras"
+```
+
+### Spring and the `test` Environment
+
+Spring reloads the application code if something changes. In the `test` environment you need to enable reloading for that to work:
+
+```ruby
+# config/environments/test.rb
+config.cache_classes = false
+```
+
+Otherwise you'll get this error:
+
+```
+reloading is disabled because config.cache_classes is true
+```
+
+This has no performance penalty.
+
+### Bootsnap
+
+Please make sure to depend on at least Bootsnap 1.4.4.
+
+
+Check Zeitwerk Compliance in the Test Suite
+-------------------------------------------
+
+The Rake task `zeitwerk:check` just eager loads, because doing so triggers built-in validations in Zeitwerk.
+
+You can add the equivalent of this to your test suite to make sure the application always loads correctly regardless of test coverage:
+
+### minitest
+
+```ruby
+require "test_helper"
+
+class ZeitwerkComplianceTest < ActiveSupport::TestCase
+  test "eager loads all files without errors" do
+    Rails.application.eager_load!
+  rescue => e
+    flunk(e.message)
+  else
+    pass
+  end
+end
+```
+
+### RSpec
+
+```ruby
+require "rails_helper"
+
+RSpec.describe "Zeitwerk compliance" do
+  it "eager loads all files without errors" do
+    expect { Rails.application.eager_load! }.not_to raise_error
+  end
+end
+```
+
+New Features You Can Leverage
+-----------------------------
+
+### Delete `require_dependency` calls
+
+All known use cases of `require_dependency` have been eliminated with Zeitwerk. You should grep the project and delete them.
+
+If your application uses Single Table Inheritance, please see the [Single Table Inheritance section](autoloading_and_reloading_constants.html#single-table-inheritance) of the Autoloading and Reloading Constants (Zeitwerk Mode) guide.
+
+
+### Qualified Names in Class and Module Definitions Are Now Possible
+
+You can now robustly use constant paths in class and module definitions:
+
+```ruby
+# Autoloading in this class' body matches Ruby semantics now.
+class Admin::UsersController < ApplicationController
+  # ...
+end
+```
+
+A gotcha to be aware of is that, depending on the order of execution, the classic autoloader could sometimes be able to autoload `Foo::Wadus` in
+
+```ruby
+class Foo::Bar
+  Wadus
+end
+```
+
+That does not match Ruby semantics because `Foo` is not in the nesting, and won't work at all in `zeitwerk` mode. If you find such corner case you can use the qualified name `Foo::Wadus`:
+
+```ruby
+class Foo::Bar
+  Foo::Wadus
+end
+```
+
+or add `Foo` to the nesting:
+
+```ruby
+module Foo
+  class Bar
+    Wadus
+  end
+end
+```
+
+### Thread-safety Everywhere
+
+In classic mode, constant autoloading is not thread-safe, though Rails has locks in place for example to make web requests thread-safe.
+
+Constant autoloading is thread-safe in `zeitwerk` mode. For example, you can now autoload in multi-threaded scripts executed by the `runner` command.
+
+### Eager Loading and Autoloading are Consistent
+
+In `classic` mode, if `app/models/foo.rb` defines `Bar`, you won't be able to autoload that file, but eager loading will work because it loads files recursively blindly. This can be a source of errors if you test things first eager loading, execution may fail later autoloading.
+
+In `zeitwerk` mode both loading modes are consistent, they fail and err in the same files.

--- a/guides/source/documents.yaml
+++ b/guides/source/documents.yaml
@@ -149,6 +149,10 @@
       url: autoloading_and_reloading_constants.html
       description: This guide documents how autoloading and reloading constants work (Zeitwerk mode).
     -
+      name: "Classic to Zeitwerk HOWTO"
+      url: "classic_to_zeitwerk_howto.html"
+      description: "This guide documents how to migrate Rails applications from `classic` to `zeitwerk` mode."
+    -
       name: Autoloading and Reloading Constants (Classic Mode)
       url: autoloading_and_reloading_constants_classic_mode.html
       description: This guide documents how autoloading and reloading constants work (Classic mode).

--- a/guides/source/ja/classic_to_zeitwerk_howto.md
+++ b/guides/source/ja/classic_to_zeitwerk_howto.md
@@ -1,0 +1,396 @@
+**DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**
+
+クラシックオートローダーからZeitwerkへの移行
+=========================
+
+本ガイドでは、Railsアプリケーションを`classic`モードから`zeitwerk`モードに移行する方法について解説します。
+
+このガイドの内容
+
+* `classic`モードと`zeitwerk`モードについて
+* `classic`から`zeitwerk`に切り替える理由
+* `zeitwerk`モードを有効にする
+* アプリケーションが`zeitwerk`モードで動いていることを検証する
+* プロジェクトが正しく読み込まれることをコマンドラインで検証する
+* プロジェクトが正しく読み込まれることをテストスイートで検証する
+* 想定されるエッジケースの対応方法
+* Zeitwerkで利用できる新機能
+
+--------------------------------------------------------------------------------
+
+`classic`モードと`zeitwerk`モードについて
+--------------------------------------------------------
+
+Railsは最初期からRails 5まで、Active Supportで実装されたオートローダーを用いていました。このオートローダーは`classic`と呼ばれ、Rails 6.xでは引き続き利用可能です。Rails 7では`classic`オートローダーが含まれなくなりました。
+
+Rails 6から、より優れた新しいオートロード方法がRailsに搭載されました。これは[Zeitwerk](https://github.com/fxn/zeitwerk)というgemに一任されています。これが`zeitwerk`モードです。デフォルトでは、Railsフレームワーク6.0および6.1の読み込みはデフォルトで`zeitwerk`モードで実行され、Rails 7で利用できるのは`zeitwerk`モードのみとなります。
+
+`classic`から`zeitwerk`に切り替える理由
+----------------------------------------
+
+`classic`オートローダーは非常に便利でしたが、取り扱いに少々注意を要したり時に混乱を招いたりする[問題](https://guides.rubyonrails.org/v6.1/autoloading_and_reloading_constants_classic_mode.html#common-gotchas)が多数存在していました。Zeitwerkはこうした問題を解決するために開発されました（その他にもさまざまな[動機](https://github.com/fxn/zeitwerk#motivation)があります）。
+
+`classic`モードは非推奨化されたので、Railsを6.xにアップグレードする際に`zeitwerk`モードに移行することを強く推奨します。
+
+この移行はRails 7で完了し、`classic`モードが含まれなくなりました。
+
+「移行するのが怖いんですが」
+-----------
+
+大丈夫です。
+
+Zeitwerkは従来のオートローダーとの互換性をできるだけ維持するように設計されています。現在のアプリケーションでオートロードが正しく行われていれば、切り替えは簡単です。大小さまざまなプロジェクトで、スムーズに切り替えられたことが報告されています。
+
+本ガイドを読めば、安心してオートローダーを切り替えられます。
+
+何らかの理由で解決方法が見当たらない状況に直面した場合は、 お気軽に[`rails/rails`リポジトリ](https://github.com/rails/rails/issues/new)のissueをオープンして、[`@fxn`](https://github.com/fxn)にメンションしてください。
+
+`zeitwerk`モードを有効にする
+-------------------------------
+
+### Rails 5.x以前のアプリケーションの場合
+
+Rails 6.0より前のバージョンを実行するアプリケーションでは`zeitwerk`モードを利用できません。最低でもRails 6.0にする必要があります。
+
+### Rails 6.xアプリケーションの場合
+
+Rails 6.xアプリケーションの場合は以下の2とおりのシナリオがあります。
+
+アプリケーションがRails 6.0または6.1のフレームワークのデフォルトを読み込んでいて、かつ`classic`モードで実行されている場合は、`classic`モードを手動でオプトアウトしなければなりません。これは以下のような形で行う必要があります。
+
+```ruby
+# config/application.rb
+config.load_defaults 6.0
+config.autoloader = :classic # この行を削除する
+```
+
+上のコメントにあるように、このオーバーライドを削除すると`zeitwerk`モードがデフォルトになります。
+
+一方、アプリケーションが古いフレームワークのデフォルトを読み込んでいる場合は、以下のように`zeitwerk`モードを明示的に有効にする必要があります。
+
+```ruby
+# config/application.rb
+config.load_defaults 5.2
+config.autoloader = :zeitwerk
+```
+
+### Rails 7アプリケーションの場合
+
+Rails 7には`zeitwerk`モードしかないので、このモードを有効するために設定を変更する必要はありません。
+
+Rails 7では`config.autoloader=`設定そのものがなくなりました。`config/application.rb`にこの設定がある場合は、その行を削除してください。
+
+アプリケーションが`zeitwerk`モードで動いていることを検証する
+------------------------------------------------------
+
+アプリケーションが`zeitwerk`モードで動いていることを検証するには、以下を実行します。
+
+```
+bin/rails runner 'p Rails.autoloaders.zeitwerk_enabled?'
+```
+
+`true`が出力されれば、`zeitwek`モードが有効です。
+
+
+アプリケーションがZeitwerkに沿っているかを確かめる
+-----------------------------------------------------
+
+`zeitwerk`モードを有効にしてから、以下を実行します。
+
+```
+bin/rails zeitwerk:check
+```
+
+チェックが成功すると以下のように出力されます。
+
+```
+% bin/rails zeitwerk:check
+Hold on, I am eager loading the application.
+All is good!
+```
+
+アプリケーションの設定によってはこの他にも出力されることがありますが、末尾に"All is good!"があればOKです。
+
+Zeitwerkで期待される定数が定義されていないファイルがあると、上のタスクで通知されます。このタスクは1ファイルごとに実行されます。問題が生じたときにタスクが先に進むと、あるファイルの読み込み失敗が他の無関係な失敗に連鎖してエラー出力が読みにくくなるためです。
+
+定数にひとつでも問題があれば、その問題を解決し、"All is good!"が出力されるまでタスクを再実行します。
+
+たとえば以下のように出力されたとします。
+
+```
+% bin/rails zeitwerk:check
+Hold on, I am eager loading the application.
+expected file app/models/vat.rb to define constant Vat
+```
+
+VATはヨーロッパの税制のことです。 `app/models/vat.rb`では`VAT`が定義済みですが、オートローダーは`Vat`を期待しています。どんな理由でこうなったのでしょうか。
+
+### 略語の扱い
+
+これはZeitwerkで最もありがちな問題で、略語が関係しています。このエラーメッセージが生じた理由を考えてみましょう。
+
+`classic`オートローダーは、すべて大文字の`VAT`をオートロードできます。その理由は、オートローダーの入力に`const_missing `の定数名が使われるからです。`VAT`という定数に対して`underscore`が呼び出されて`vat`が生成され、これを元に`vat.rb`というファイルを検索し、ファイルは正常に見つかります。
+
+新しいZeitwerkオートローダーの入力はファイルシステムになっています。`vat.rb`というファイルがあると、Zeitwerkは`vat`に対して`camelize`を呼び出し、冒頭のみが大文字の`Vat`が生成されます。これにより、`Vat`という定数名が定義されていることが期待されます。以上がエラーメッセージの内容です。
+
+これは、以下のように`ActiveSupport::Inflector`の語尾活用機能を用いて略語を指定するだけで簡単に修正できます。
+
+```ruby
+# config/initializers/inflections.rb
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym "VAT"
+end
+```
+
+上の方法は、Active Supportの語尾活用機能をグローバルに変更します。これで問題ない場合もありますが、オートローダーで用いられる語尾活用機能にオーバーライドを渡したい場合は、以下のようにします。
+
+```ruby
+# config/initializers/zeitwerk.rb
+Rails.autoloaders.each do |autoloader|
+  autoloader.inflector.inflect("vat" => "VAT")
+end
+```
+
+以上を反映すればチェックはパスします。
+
+```
+% bin/rails zeitwerk:check
+Hold on, I am eager loading the application.
+All is good!
+```
+
+### concernsについて
+
+以下のように、`concerns`サブディレクトリを持つ標準的な構造からのオートロードやeager loadingを行えます【チェック】。
+
+```
+app/models
+app/models/concerns
+```
+
+`app/models/concerns`ディレクトリはデフォルトではオートロードのパスに属しているので、これがルートディレクトリと見なされます。そのため、デフォルトでは`app/models/concerns/foo.rb`ファイルで定義されるのは`Concerns::Foo`ではなく`Foo`になります。
+
+アプリケーションで`Concerns`が名前空間として使われている場合は、以下の2つの方法があります。
+
+1. これらのクラスやモジュールから`Concerns`名前空間を削除してクライアントコードを更新する。
+2. オートロードのパスから`app/models/concerns`を除外することで現状のままにする。
+
+  ```ruby
+  # config/initializers/zeitwerk.rb
+  ActiveSupport::Dependencies.
+    autoload_paths.
+    delete("#{Rails.root}/app/models/concerns")
+  ```
+
+### オートロードのパスに`app`を追加する
+
+プロジェクトによっては、たとえば`API::Base`を定義する`app/api/base.rb`を置き、オートロードパスに`app`を追加することで利用したい場合もあります。
+
+Railsは自動的に`app`のすべてのサブディレクトリもオートロードパスに追加するので（アセットのディレクトリなどは除く）、`app/models/concerns`で起きたのと似たようなネステッドrootディレクトリの問題がここでも起きます。今後この設定はこのままでは機能しません。
+
+ただし、以下のようにイニシャライザでオートロードパスから`app/api`を削除すれば現状の構造を維持できます。
+
+```ruby
+# config/initializers/zeitwerk.rb
+ActiveSupport::Dependencies.
+  autoload_paths.
+  delete("#{Rails.root}/app/api")
+```
+
+### オートロードした定数と明示的な名前空間
+
+ファイル内で、たとえば以下のように`Hotel`という名前空間が定義されているとします。
+
+```
+app/models/hotel.rb         # Hotelを定義する
+app/models/hotel/pricing.rb # Hotel::Pricingを定義する
+```
+
+この`Hotel`定数は、以下のように`class`または`module`キーワードで設定しなければなりません。
+
+```ruby
+class Hotel
+end
+```
+
+上は問題ありません。
+
+ただし、以下は無効です。
+
+```ruby
+Hotel = Class.new
+```
+
+または
+
+```ruby
+Hotel = Struct.new
+```
+
+これらは`Hotel::Pricing`などの子オブジェクトを探索できません。
+
+これらの制約は、明示的な名前空間にのみ適用されます。名前空間を定義しないクラスやモジュールであれば上述の記法でも定義できます。
+
+### 1ファイルに1定数（同一トップレベルあたり）
+
+`classic`モードでは、以下のように同一トップレベルに複数の定数を定義して、それらすべてを再読み込みすることも技術的に可能でした。以下のコード例で考えます。
+
+```ruby
+# app/models/foo.rb
+
+class Foo
+end
+
+class Bar
+end
+```
+
+上の`Bar`は本来オートロードできないにもかかわらず、`Foo`をオートロードすると`Bar`もオートロードされました。
+
+これは`zeitwerk`モードでは利用できません。`Bar`は専用の`bar.rb`ファイルに移動する必要があります。1ファイルにつきトップレベル定数1個という規則です。
+
+これが影響するのは、上のコード例のように同一トップレベルに置かれた定数だけです。以下のようなネストしたクラスやモジュールには影響しません。
+
+```ruby
+# app/models/foo.rb
+
+class Foo
+  class InnerClass
+  end
+end
+```
+
+アプリケーションが`Foo`を再読み込みすると、`Foo::InnerClass`も再読み込みされます。
+
+### `config.autoload_paths`について
+
+以下のようにワイルドカードを含む設定では注意が必要です。
+
+```ruby
+config.autoload_paths += Dir["#{config.root}/extras/**/"]
+```
+
+`config.autoload_paths`のどの要素もトップレベルの名前空間（`Object`）を表さなければならないので、上の設定は無効です。
+
+これは、以下のようにワイルドカードを削除するだけで修正できます。
+
+```ruby
+config.autoload_paths << "#{config.root}/extras"
+```
+
+### spring gemと`test`環境
+
+spring gemは、アプリケーションコードが変更されると再読み込みします。`test`環境でこの再読み込みを有効にするには、以下のようにする必要があります。
+
+```ruby
+# config/environments/test.rb
+config.cache_classes = false
+```
+
+そうしないと、以下のエラーが発生します。
+
+```
+reloading is disabled because config.cache_classes is true
+```
+
+この設定でパフォーマンスは落ちません。
+
+### bootsnap gem
+
+少なくともbootsnap 1.4.4以上に依存するようにしてください。
+
+
+Zeitwerk準拠をテストスイートでチェックする
+-------------------------------------------
+
+Rakeタスク`zeitwerk:check`は、単にeager loadingを実行します。これによってZeitwerkの組み込みバリデーションがトリガされます。
+
+これと同等のタスクをテストスイートに追加すれば、テストカバレッジに関係なくアプリケーションの読み込みが常に正しく行われるようになります。
+
+### minitestの場合
+
+```ruby
+require "test_helper"
+
+class ZeitwerkComplianceTest < ActiveSupport::TestCase
+  test "eager loads all files without errors" do
+    Rails.application.eager_load!
+  rescue => e
+    flunk(e.message)
+  else
+    pass
+  end
+end
+```
+
+### RSpecの場合
+
+```ruby
+require "rails_helper"
+
+RSpec.describe "Zeitwerk compliance" do
+  it "eager loads all files without errors" do
+    expect { Rails.application.eager_load! }.not_to raise_error
+  end
+end
+```
+
+Zeitwerkで利用できる新機能
+-----------------------------
+
+### `require_dependency`呼び出しの削除
+
+Zeitwerkによって、`require_dependency`の既知のユースケースはすべて削除されました。プロジェクトをgrepして`require_dependency`をすべて削除してください。
+
+アプリケーションでSTIを利用している場合は、『定数の自動読み込みと再読み込み (Zeitwerk)ガイド』の『[STI(単一テーブル継承)』を参照してください。
+](/autoloading_and_reloading_constants.html#sti-単一テーブル継承)
+
+### クラスやモジュールの定義内で定数名を修飾可能になった
+
+クラスやモジュールの定義で、以下のような定数パスを安定して利用できるようになりました。
+
+```ruby
+# このクラスの本体でのオートロードがRubyのセマンティクスと一致するようになった
+class Admin::UsersController < ApplicationController
+  # ...
+end
+```
+
+ひとつ注意すべきは、実行順序によってはclassicオートローダーで以下の`Foo::Wadus`をオートロードできる場合があった点です。
+
+```ruby
+class Foo::Bar
+  Wadus
+end
+```
+
+この`Foo`はネストの中に存在しないので、上はRubyのセマンティクスと一致しません。そのため、これは`zeitwerk`モードではまったく動作しません。もしこうしたエッジケースに遭遇した場合は、以下のように`Foo::Wadus`という修飾名を利用できます。
+
+```ruby
+class Foo::Bar
+  Foo::Wadus
+end
+```
+
+あるいは、以下のように`Foo`をネストに追加します。
+
+```ruby
+module Foo
+  class Bar
+    Wadus
+  end
+end
+```
+
+### あらゆる場所でスレッドセーフになる
+
+RailsにはWebリクエストをスレッドセーフにするロックが用意されているにもかかわらず、`classic`モードの定数自動読み込みはスレッドセーフではありません。
+
+`zeitwerk`モードの定数自動読み込みはスレッドセーフです。たとえば、`runner`コマンドで実行されるマルチスレッドのスクリプトをオートロードできるようになりました。
+
+### eager loadingとオートロードが一貫するようになった
+
+`classic`モードでは、`app/models/foo.rb`ファイルで`Bar`が定義されていると、このファイルをオートロードできません。しかし`classic`モードはファイルの読み込みを盲目的に再帰するので、このファイルのeager loadingは可能です。テストを最初にeager loadingする形で実行すると、その後に行われるオートロードで実行が失敗する可能性があります。
+
+`zeitwerk`モードではどちらの読み込みモードも一貫しているので、テストの失敗やエラーは同じファイル内で発生します。
+

--- a/guides/source/ja/documents.yaml
+++ b/guides/source/ja/documents.yaml
@@ -159,6 +159,10 @@
       url: autoloading_and_reloading_constants.html
       description: 定数の自動読み込みや再読み込みの動作について解説します。(Zeitwerk モード)
     -
+      name: "ClassicからZeitwerkへの移行"
+      url: "classic_to_zeitwerk_howto.html"
+      description: "Railsアプリケーションを`classic`モードから`zeitwerk`モードに移行する手順を解説します。"
+    -
       name: 定数の自動読み込みと再読み込み (Classic)
       url: autoloading_and_reloading_constants_classic_mode.html
       description: 定数の自動読み込みや再読み込みの動作について解説します。(Classic モード)


### PR DESCRIPTION
現時点のclassic_to_zeitwerk_howto.mdに対応する訳文をひとまずWIPでプルリク化しました。

* edge: [Classic to Zeitwerk HOWTO — Ruby on Rails Guides](https://edgeguides.rubyonrails.org/classic_to_zeitwerk_howto.html)
* 英語版:  https://raw.githubusercontent.com/rails/rails/573bba3ba9a653551e078802e09e8585e03dd49a/guides/source/classic_to_zeitwerk_howto.md

## メモ

* documents.yamlは日本語英語ともclassic_to_zeitwerk_howto.mdの追加のみ反映してあります。
* Classic版オートローダーガイドはRails 7では消える予定です。現在は日本語版英語版にはありますが、edgeでは既に消えています。今はdocuments.yamlではClassic版オートローダーガイドを残してありますが、Rails 7が出たら消すことになります。
  * [Autoloading and Reloading Constants \(Classic Mode\) — Ruby on Rails Guides](https://guides.rubyonrails.org/autoloading_and_reloading_constants_classic_mode.html)