### PR TITLE
コードブロック内のspan.errへの対応

### DIFF
--- a/guides/source/ja/active_job_basics.md
+++ b/guides/source/ja/active_job_basics.md
@@ -235,7 +235,7 @@ Active Jobが提供するフックを用いて、ジョブのライフサイク�
 
 ```ruby
 class GuestsCleanupJob < ApplicationJob
-  queue_as :default
+  queue_as :default
 
   around_perform :around_cleanup
   


### PR DESCRIPTION
https://railsguides.jp/active_job_basics.html#%E3%82%B3%E3%83%BC%E3%83%AB%E3%83%90%E3%83%83%E3%82%AF  
spanにより余計な表示が挿入されていたのでインデントを修正しました。