### PR TITLE
シンタックスハイライトをhtmlからerbに修正

### DIFF
--- a/guides/source/ja/action_view_overview.md
+++ b/guides/source/ja/action_view_overview.md
@@ -1487,7 +1487,7 @@ NB: この出力にはエスケープされていない'<'、'>'、'&'文字が�
 
 `csrf-param` metaタグと`csrf-token` metaタグを返します。これらの名称はそれぞれ、クロスサイトリクエストフォージェリ（CSRF: cross-site request foregery）のパラメータとトークンが元になっています。
 
-```html
+```erb
 <%= csrf_meta_tags %>
 ```
 


### PR DESCRIPTION
erbで書かれているサンプルコードにhtmlのシンタックスハイライトが使用されていたため修正しました。