### PR TITLE
レイアウトとレンダリング」の「実際のレンダリング〜」の注釈に原文の変更が反映されていなかったため反映

### DIFF
--- a/guides/source/ja/layouts_and_rendering.md
+++ b/guides/source/ja/layouts_and_rendering.md
@@ -96,7 +96,7 @@ end
 <%= link_to "New book", new_book_path %>
 ```
 
-NOTE: 実際のレンダリングは、`ActionView::TemplateHandlers`のサブクラスで行われます。本ガイドではレンダリングの詳細については触れませんが、テンプレートハンドラの選択がビューテンプレートファイルの拡張子によって制御されているという重要な点は理解しておいてください。Rails 2以降におけるビューテンプレートの標準拡張子は、ERB (HTML + Embedded RuBy) でレンダリングする場合は`.erb`、Builder (XMLジェネレータ) でレンダリングする場合は`.builder`です。
+NOTE: 実際のレンダリングは、[`ActionView::Template::Handlers`](http://api.rubyonrails.org/classes/ActionView/Template/Handlers.html)の名前空間の中でネストされたクラスで行われます。本ガイドではレンダリングの詳細については触れませんが、テンプレートハンドラの選択がビューテンプレートファイルの拡張子によって制御されているという重要な点は理解しておいてください。
 
 ### `render`を使用する
 

--- a/guides/source/ja/layouts_and_rendering.md
+++ b/guides/source/ja/layouts_and_rendering.md
@@ -205,7 +205,7 @@ render inline: "<% products.each do |p| %><p><%= p.name %></p><% end %>"
 
 WARNING: このオプションを実際に使用する意味はほぼないと思われます。コントローラのコードにERBを混在させると、RailsのMVC指向が崩されるだけでなく、開発者がプロジェクトのロジックを追いかけることが困難になってしまいます。通常のERBビューを使用してください。
 
-インラインでは、デフォルトでERBを使用して出力を行います。`:type`オプションで:builderを指定すると、ERBに代えてBuilderが使用されます。
+インラインでは、デフォルトでERBを使用して出力を行います。`:type`オプションで`:builder`を指定すると、ERBに代えてBuilderが使用されます。
 
 ```ruby
 render inline: "xml.p {'Horrid coding practice!'}", type: :builder


### PR DESCRIPTION
以下のコミットの変更が日本語訳に反映されていなかったため反映しました

cf. https://github.com/rails/rails/commit/264f4a6b1456d8ab66bd444a1f8d96ebd44d17f3

```diff
- NOTE: The actual rendering is done by subclasses of `ActionView::TemplateHandlers`. This guide does not dig into that process, but it's important to know that the file extension on your view controls the choice of template handler. Beginning with Rails 2, the standard extensions are `.erb` for ERB (HTML with embedded Ruby), and `.builder` for Builder (XML generator).
+ NOTE: The actual rendering is done by nested classes of the module [`ActionView::Template::Handlers`](http://api.rubyonrails.org/classes/ActionView/Template/Handlers.html). This guide does not dig into that process, but it's important to know that the file extension on your view controls the choice of template handler.
```

該当行は以下のコミットで api.rubyonrails.org へのリンクが https に変更されていますが他にも修正箇所が多くあるため別のプルリクエストで対応予定です 🙏 

cf. https://github.com/rails/rails/commit/d9f1cc05b586f747b679f2aa73b57be364f0fd49

軽微な修正なため併せて :builder をインラインコードにする修正も行っています