### PR TITLE
Fix translation of routing constraints note

### DIFF
--- a/guides/source/ja/routing.md
+++ b/guides/source/ja/routing.md
@@ -710,7 +710,7 @@ namespace :admin do
 end
 ```
 
-NOTE: リクエストベースの制限は、<a href="action_controller_overview.html#requestオブジェクト">Requestオブジェクト</a>に対してあるメソッドを呼び出すことで実行されます。メソッド呼び出し時にハッシュキーと同じ名前をメソッドに渡し、返された値をハッシュ値と比較します。従って、制限された値は、対応するRequestオブジェクトメソッドが返す型と一致する必要があります。たとえば、`constraints: { subdomain: 'api' }`という制限は`api`サブドメインに期待どおりマッチしますが、`constraints: { subdomain: :api }`のようにシンボルを使った場合は`api`サブドメインに一致しません。`request.subdomain`が返す`'api'`は文字列型であるためです。
+NOTE: リクエストベースの制限は、<a href="action_controller_overview.html#requestオブジェクト">Requestオブジェクト</a>に対してあるメソッドを呼び出すことで実行されます。ハッシュキーと同じ名前のメソッドを呼び出し、返された値をハッシュの値と比較します。従って、制限された値は、対応するRequestオブジェクトのメソッドが返す型と一致する必要があります。たとえば、`constraints: { subdomain: 'api' }`という制限は`api`サブドメインに期待どおりマッチしますが、`constraints: { subdomain: :api }`のようにシンボルを使った場合は`api`サブドメインに一致しません。`request.subdomain`が返す`'api'`は文字列型であるためです。
 
 NOTE: `format`の制限には例外があります。これはRequestオブジェクトのメソッドですが、すべてのパスに含まれる暗黙的なオプションのパラメータでもあります。`format`の制限よりセグメント制限が優先されます。たとえば、`get 'foo'、constraints: { format： 'json' }`は`GET /foo`と一致します。これはデフォルトでformatがオプションであるためです。しかし、次のように[lambdaを使う](#高度な制限)ことができます。`get 'foo', constraints: lambda { |req| req.format == :json }` このルーティング指定は明示的なJSONリクエストにのみ一致します。
 


### PR DESCRIPTION
routingのガイドを読んでいて、少し気になったので3つの修正をします。

原文は次のように書かれているところです。

> Request constraints work by calling a method on the [Request object](https://guides.rubyonrails.org/action_controller_overview.html#the-request-object) with the same name as the hash key and then comparing the return value with the hash value. Therefore, constraint values should match the corresponding Request object method return type. For example: `constraints: { subdomain: 'api' }` will match an `api` subdomain as expected. However, using a symbol `constraints: { subdomain: :api }` will not, because `request.subdomain` returns `'api'` as a String.



1つ目は、「メソッド呼び出し時にハッシュキーと同じ名前をメソッドに渡し、」に違和感がありました。
この文ではハッシュキーを何かしらのメソッドに引数として渡しているように読めますが、実際にはハッシュキーと同じ名前のメソッドを呼んでいます。そのため、そのように翻訳を修正しました。



2つ目は、その続きの「返された値をハッシュ値と比較します。」の部分です。
ハッシュ値と言うと`Object#hash`の戻り値のようなものを想像しますが、実際にはここでは「呼び出したハッシュのキーに対応する値」が比較対象になります。それがわかりやすいように「ハッシュの値」と変更してみました。


3つ目は細かい点ですが、「Requestオブジェクトメソッド」となっていて「オブジェクトメソッド」が1語になっていたので、これを「オブジェクトのメソッド」としました。
