### PR TITLE
コントローラの機能テストのサンプルのテストコードのインデントを修正しました。

### DIFF
--- a/guides/source/ja/testing.md
+++ b/guides/source/ja/testing.md
@@ -1050,9 +1050,9 @@ create    test/controllers/articles_controller_test.rb
 ```ruby
 # articles_controller_test.rb
 class ArticlesControllerTest < ActionDispatch::IntegrationTest
-   test "should get index" do
-     get articles_url
-     assert_response :success
+  test "should get index" do
+    get articles_url
+    assert_response :success
   end
 end
 ```


### PR DESCRIPTION
コントローラの機能テストのサンプルのテストコードのインデントがずれてそうな箇所があったので以下の原著に合わせて修正してみました。いかがでしょうか。

``` ruby
class ArticlesControllerTest < ActionDispatch::IntegrationTest
  test "should get index" do
    get articles_url
    assert_response :success
  end
end
```

ref: https://guides.rubyonrails.org/testing.html#what-to-include-in-your-functional-tests