### PR TITLE
不要な記号を削除

### DIFF
--- a/guides/source/ja/active_support_core_extensions.md
+++ b/guides/source/ja/active_support_core_extensions.md
@@ -1188,7 +1188,7 @@ NOTE: 定義は`active_support/core_ext/string/filters.rb`にあります。
 "active".inquiry.inactive?       # => false
 ```
 
-NOTE: 定義は`active_support/core_ext/string/inquiry.rb`にあります。****
+NOTE: 定義は`active_support/core_ext/string/inquiry.rb`にあります。
 
 ### `starts_with?`と`ends_with?`
 


### PR DESCRIPTION
注釈部分の末尾に不要な記号`*`があったので削除しました。