### PR TITLE
タイトルが2行に跨るときのline-heightを調整

### DIFF
--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -601,6 +601,10 @@ h3 a, h4 a, h5 a, h6 a {
     margin: 0;
     padding: 0;
   }
+  dd {
+    line-height: 1.4;
+    margin-bottom: 0.5em;
+  }
   dt {padding:0; margin: 0.5em 0 0;}
 
   .L, .R {float: left; width: 50%; margin: 0; padding: 0;}


### PR DESCRIPTION
タイトルが2行になっても見えやすいよう調整しました🙏

<img width="589" alt="スクリーンショット 2021-12-22 12 23 45" src="https://user-images.githubusercontent.com/48109243/147030259-b60fee37-2a51-4cef-9c5c-309ca772ab37.png">
