### PR TITLE
PDF生成エラーになるシンタックスハイライト言語指定を削除

### DIFF
--- a/guides/source/ja/active_record_callbacks.md
+++ b/guides/source/ja/active_record_callbacks.md
@@ -504,7 +504,7 @@ class User < ApplicationRecord
 end
 ```
 
-```irb
+```
 irb> @user = User.create # 何も出力しない
 
 irb> @user.save # updating @user

--- a/guides/source/ja/form_helpers.md
+++ b/guides/source/ja/form_helpers.md
@@ -26,7 +26,7 @@ NOTE: このガイドはフォームヘルパーとその引数について網�
 
 最も基本的なフォームヘルパーは[`form_with`](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-form_with)です。
 
-```erb
+```
 <%= form_with do |form| %>
   Form contents
 <% end %>


### PR DESCRIPTION
通常`erb`は大丈夫なのですが、`form_helpers.md `の該当部分だけエラーになってしまうので指定なしにしています🙏