### PR TITLE
定数の自動読み込みと再読み込みページの表記ミス修正

### DIFF
--- a/guides/source/ja/autoloading_and_reloading_constants.md
+++ b/guides/source/ja/autoloading_and_reloading_constants.md
@@ -18,7 +18,7 @@
 はじめに
 ------------
 
-INFO: 本ガイドでは、Rails 6.0で新たに導入された`Zeitwerk`モードの自動読み込みについて解説します。Rails 5.2 以降の`Zeitwerk`モードについては、[定数の自動読み込みと再読み込み (Zeitwerk)](/autoloading_and_reloading_constants_classic_mode.html) を参照してください。
+INFO: 本ガイドでは、Rails 6.0で新たに導入された`Zeitwerk`モードの自動読み込みについて解説します。Rails 5.2 以前の`Classic`モードについては、[定数の自動読み込みと再読み込み (Classic)](/autoloading_and_reloading_constants_classic_mode.html) を参照してください。
 
 通常のRubyプログラムのクラスであれば、依存関係のあるプログラムを明示的に読み込む必要があります。たとえば、以下のコントローラでは`ApplicationController`クラスや`Post`クラスを用いており、通常、それらを呼び出すには`require`する必要があります。
 


### PR DESCRIPTION
定数の自動読み込みと再読み込みページの表記ミス修正

- ClassicモードのページタイトルがZeitwerkモードのものになっていたのを修正
- Rails 5.2 `以降`になっていたのを`以前`に修正