### PR TITLE
comparisonのコード例のstart_dateとend_dateが逆になっていたので修正

### DIFF
--- a/guides/source/ja/active_record_validations.md
+++ b/guides/source/ja/active_record_validations.md
@@ -304,7 +304,7 @@ end
 
 ```ruby
 class Promotion < ApplicationRecord
-  validates :start_date, comparison: { greater_than: :end_date }
+  validates :end_date, comparison: { greater_than: :start_date }
 end
 ```
 


### PR DESCRIPTION
終了日が開始日よりも大きい値になるのが一般的かと思いますので、オリジナルの方に合わせてコード例を修正させていただきました。
https://edgeguides.rubyonrails.org/active_record_validations.html#comparison