### PR TITLE
I18nのページで正しく表示されていない箇所を修正する

### DIFF
--- a/guides/source/ja/i18n.md
+++ b/guides/source/ja/i18n.md
@@ -392,7 +392,7 @@ end
 
 ![rails i18n demo translation missing](images/i18n/demo_translation_missing.png)
 
-NOTE: Railsはt` (`translate`) ヘルパーメソッドを自動的にビューに追加するので、`I18n.t`のようにフルスペルで書かずに済みます。さらに、このヘルパーは訳文が見つからない場合にエラーメッセージを `<span class="translation_missing">` でラップして表示してくれます。
+NOTE: Railsは`t` (`translate`) ヘルパーメソッドを自動的にビューに追加するので、`I18n.t`のようにフルスペルで書かずに済みます。さらに、このヘルパーは訳文が見つからない場合にエラーメッセージを `<span class="translation_missing">` でラップして表示してくれます。
 
 ### 訳文を与えて文字列を国際化する
 


### PR DESCRIPTION
### やったこと
'`' が抜けてたので追加しました

### before
![スクリーンショット 2022-02-16 6 34 06](https://user-images.githubusercontent.com/56573/154153199-53853719-6f82-480c-aebb-ef77c04867d0.png)

### after
![スクリーンショット 2022-02-16 6 33 56](https://user-images.githubusercontent.com/56573/154153189-edc2ce58-7b28-4411-8805-6a1a034d0c51.png)
