### PR TITLE
メンテナンスポリシーのOGPで説明文が正しく表示されるように修正した

### DIFF
--- a/guides/source/ja/documents.yaml
+++ b/guides/source/ja/documents.yaml
@@ -246,7 +246,7 @@
   name: メンテナンスポリシー
   documents:
     -
-      name: Rails のメンテナンスポリシー
+      name: Ruby on Rails のメンテナンスポリシー
       url: maintenance_policy.html
       description: 現在サポートされているRuby on Railsのバージョンと、次期バージョンのリリース見込み時期について記載されています。
 -


### PR DESCRIPTION
### 背景
メンテナンスポリシーの OGP の説明文がデフォルトの表示になっているので修正したい。

<img width="505" alt="スクリーンショット 2022-02-21 10 38 09" src="https://user-images.githubusercontent.com/41533420/154877240-f7115da0-3a74-4d41-b97b-93fc46634239.png">

### 表示の必要なこと
- `railsguides.jp/guides/source/ja/documents.yaml `に該当のタイトルと説明が必要
- name とタイトルの文字列が完全一致する必要がある

### やったこと
name とページタイトルの文字列が完全一致するように修正した。
🔽 参考
![スクリーンショット 2022-02-21 10 55 46](https://user-images.githubusercontent.com/41533420/154878288-889edde0-4bad-4c97-900c-bcfb261cd5f1.png)


### メモ
ローカルでのOGPの表示確認はできていません。