### PR TITLE
Fix typo in association_basics.md

### DIFF
--- a/guides/source/ja/association_basics.md
+++ b/guides/source/ja/association_basics.md
@@ -834,7 +834,7 @@ irb> a.first_name == b.writer.first_name
 
 * `association`
 * `association=(associate)`
-* `buildassociation(attributes = {})`
+* `build_association(attributes = {})`
 * `create_association(attributes = {})`
 * `create_association!(attributes = {})`
 * `reload_association`


### PR DESCRIPTION
素晴らしいドキュメントを提供していただき、ありがとうございます。

`association_basics.md` に typo があり、変更しました。

- before: `buildassociation`
- after: `build_association`
