### PR TITLE
Active Record クエリインターフェイスの文言を文脈に合わせて修正

### DIFF
--- a/guides/source/ja/active_record_querying.md
+++ b/guides/source/ja/active_record_querying.md
@@ -1407,7 +1407,7 @@ Customer.includes(:orders, :reviews)
 Customer.includes(orders: {books: [:supplier, :author]}).find(1)
 ```
 
-上のコードは、id=1のカテゴリを検索し、関連付けられたすべての記事とそのタグやコメント、およびすべてのコメントのゲスト関連付けを一括読み込みします。
+上のコードは、id=1の顧客を検索し、関連付けられたすべての注文、それぞれの本の仕入先と著者を読み込みます。
 
 ### 関連付けのeager loadingで条件を指定する
 


### PR DESCRIPTION
コードと日本語の説明文章が合っていなかったため、文言を修正しました。

補足ですが、原著は以下のようになっておりコードと説明文章の食い違いはありませんでした。

> Customer.includes(orders: {books: [:supplier, :author]}).find(1)
> 
> This will find the customer with id 1 and eager load all of the associated orders for it, the books for all of the orders, and the author and supplier for each of the books.
> https://guides.rubyonrails.org/active_record_querying.html#nested-associations-hash