### PR TITLE
Fix typo in command_line.md

### DIFF
--- a/guides/source/ja/command_line.md
+++ b/guides/source/ja/command_line.md
@@ -102,7 +102,7 @@ $ rails new commandsapp
 | `--skip-action-cable`   | Action Cableのファイルをスキップする                                     |
 | `--skip-sprockets`      | Sprocketsのファイルをスキップする                                        |
 | `--skip-javascript`     | JavaScriptのファイルをスキップする                                       |
-| `--skip-turbolinks`     | turbolinks gemをスキッpする                                         |
+| `--skip-turbolinks`     | turbolinks gemをスキップする                                         |
 | `--skip-test`           | テストファイルをスキップする                                             |
 | `--skip-system-test`    | システムテストファイルをスキップする                                      |
 | `--skip-bootsnap`       | bootsnap gemをスキップする                                           |


### PR DESCRIPTION
typoを見つけたので修正しました。