### PR TITLE
U+00a0のスペースを通常のスペース（U+0020）に変更

### DIFF
--- a/guides/source/ja/action_controller_overview.md
+++ b/guides/source/ja/action_controller_overview.md
@@ -216,7 +216,7 @@ strong parametersは、Action ControllerのパラメータをActive Modelの「�
 
 ```ruby
 class PeopleController < ActionController::Base
-  # 以下のコードはActiveModel::ForbiddenAttributesError例外を発生する
+  # 以下のコードはActiveModel::ForbiddenAttributesError例外を発生する
   # （明示的な許可を行なわずに、パラメータを一括で渡してしまう
   # 危険な「マスアサインメント」が行われているため）
   def create


### PR DESCRIPTION
Action Controller の概要のページで、
一部、U+00a0のスペースになっており、赤い四角が表示されてしまっていましたので、修正しました。

<img width="713" alt="image" src="https://user-images.githubusercontent.com/48155865/161405882-eb02eb24-42fe-4616-af8e-65015be5d337.png">