### PR TITLE
Add the back quotation to fix the `upgrading_ruby_on_rails.md`

### DIFF
--- a/guides/source/ja/upgrading_ruby_on_rails.md
+++ b/guides/source/ja/upgrading_ruby_on_rails.md
@@ -133,7 +133,7 @@ Rails 7では、オートロードのモードを指定する`config.autoloader=
 
 * `ActiveSupport::Dependencies.mechanism`やそのリーダーやライターを使っている場合は、`config.cache_classes`のアクセスで置き換える必要があります。
 
-* オートローダーの動作をトレースしたい場合、ActiveSupport::Dependencies.verbose=`は利用できなくなりました。`config/application.rb`で`Rails.autoloaders.log!`をスローしてください。
+* オートローダーの動作をトレースしたい場合、`ActiveSupport::Dependencies.verbose=`は利用できなくなりました。`config/application.rb`で`Rails.autoloaders.log!`をスローしてください。
 
 `ActiveSupport::Dependencies::Reference`や`ActiveSupport::Dependencies::Blamable`などの補助的なクラスやモジュールも削除されました。
 


### PR DESCRIPTION
### 背景
`upgrading_ruby_on_rails.md`ファイル内でバッククォートが漏れている箇所がありました。


### 行なったこと
Rails アップグレードガイド内のテキストで、「オートローダーの動作をトレースしたい場合、」以降の部分にバッククォートを一箇所追加しました。 / 453f371d4abbe01860b0daea794b5b9f03f33b96


### スクリーンショット
修正前
<img width="734" alt="スクリーンショット 2022-04-05 15 27 33" src="https://user-images.githubusercontent.com/57083948/161697788-f51ce0db-815d-4d6f-8c71-dd1f2e38d7fe.png">

修正後
<img width="665" alt="スクリーンショット 2022-04-05 15 53 20" src="https://user-images.githubusercontent.com/57083948/161697755-1551ecce-207b-4781-81d1-026fb3a85602.png">