### PR TITLE
Change protocol to access rails/rails in GitHub

### DIFF
--- a/guides/rails_guides.rb
+++ b/guides/rails_guides.rb
@@ -17,7 +17,7 @@ env_value = ->(name) { ENV[name].presence }
 env_flag  = ->(name) { "1" == env_value[name] }
 
 version = env_value["RAILS_VERSION"]
-edge    = `git ls-remote https://github.com/rails/rails HEAD`.split(' ').first unless version
+edge    = `git ls-remote git@github.com:rails/rails HEAD`.split(' ').first unless version
 
 RailsGuides::GeneratorJa.new(
   edge:     edge,


### PR DESCRIPTION
This fixes the following error when generating HTML files in local:

> fatal: remote error:
>   The unauthenticated git protocol on port 9418 is no longer supported.
> Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

cf. Improving Git protocol security on GitHub - GitHub Blog
https://github.blog/2021-09-01-improving-git-protocol-security-github/

> March 15, 2022 - Changes made permanent.
> 
> We’ll permanently stop accepting DSA keys. RSA keys uploaded after the cut-off point above will work only with SHA-2 signatures (but again, RSA keys uploaded before this date will continue to work with SHA-1). The deprecated MACs, ciphers, and unencrypted Git protocol will be permanently disabled.