### PR TITLE
Fix typo in configuring

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -288,7 +288,7 @@ SHA256ハッシュ生成に使われるオプション文字列です。この�
 
 #### `config.assets.compile`
 
-production環境での動的なSprocketsコンパイルをオンにするかどうかを指定するboolan値です。
+production環境での動的なSprocketsコンパイルをオンにするかどうかを指定するboolean値です。
 
 #### `config.assets.logger`
 


### PR DESCRIPTION
configuring にある boolan を boolean に修正しました。

Ruby on Rails Guides: https://guides.rubyonrails.org/configuring.html#config-assets-compile
Ruby on Rails ガイド: https://railsguides.jp/configuring.html#config-assets-compile
