### PR TITLE
i18n.mdのtypo修正

### DIFF
--- a/guides/source/ja/i18n.md
+++ b/guides/source/ja/i18n.md
@@ -257,7 +257,6 @@ scope "(:locale)", locale: /en|nl/ do
   resources :books
 end
 ```
-```
 
 上記のようにロケールを必須でない設定にすることで、`http://localhost:3001/books`のようにロケールを含まないURLを使っても`Routing Error`は生じなくなります。これは、ロケールの指定がなければデフォルトロケールを使うようにしたい場合に便利です。
 


### PR DESCRIPTION
コードブロックの指定が二重で記載されていたため、
想定とは違う表示になっていると思われます。