### PR TITLE
Tweak translation in autoloading_and_reloading_constants.md

### DIFF
--- a/guides/source/ja/autoloading_and_reloading_constants.md
+++ b/guides/source/ja/autoloading_and_reloading_constants.md
@@ -96,24 +96,13 @@ module MyApplication
 end
 ```
 
-また、Railsエンジンはエンジンクラスの本体に独自の`config/environments/*.rb`を追加することも可能です。
+Railsエンジンは、エンジンクラスの本文の中とエンジン自身の`config/environments/*.rb`の中から自動読み込みパスを追加することも可能です。
 
 WARNING: `ActiveSupport::Dependencies.autoload_paths`はくれぐれも改変しないでください。自動読み込みパスを変更するpublicなインターフェイスは`config.autoload_paths`の方です。
 
 WARNING: アプリケーションの起動中は、自動読み込みパス内のコードは自動で読み込まれません（特に`config/initializers/*.rb`の中）。正しい方法については、後述の[アプリケーション起動時の自動読み込み](#アプリケーション起動時の自動読み込み)を参照してください。
 
 自動読み込みパスは、`Rails.autoloaders.main`オートローダーによって管理されます。
-
-`$LOAD_PATH`
-----------
-
-自動読み込みパスはデフォルトで`$LOAD_PATH`に追加されます。ただし、Zeitwerkの内部では絶対ファイル名が使われますし、アプリケーションで自動読み込み可能なファイルを`require`すべきではありませんので、`$LOAD_PATH`に追加されたこれらのディレクトリは実際には不要です。この動作は以下のフラグで無効にできます。
-
-```ruby
-config.add_autoload_paths_to_load_path = false
-```
-
-こうすることで探索量が削減されて、正しい`require`呼び出しがわずかに高速化される可能性があります。また、アプリケーションで[Bootsnap](https://github.com/Shopify/bootsnap)を使っている場合も、ライブラリの不要なインデックス構築や、必要なメモリ量が節約されます。
 
 `config.autoload_once_paths`
 --------------------------
@@ -130,7 +119,7 @@ module MyApplication
 end
 ```
 
-また、Railsエンジンはエンジンクラスの本体に独自の`config/environments/*.rb`を追加することも可能です。
+Railsエンジンは、エンジンクラスの本文の中とエンジン自身の`config/environments/*.rb`の中から自動読み込みパスを追加することも可能です。
 
 INFO: `app/serializers`を`config.autoload_once_paths`に追加すると、`app/`の下のカスタムディレクトリであってもRailsはこれを自動読み込みパスとみなさなくなります。この設定を行うと、このルールが上書きされます。
 
@@ -314,8 +303,7 @@ eager loadingは`config.eager_load`フラグで制御します。これは`produ
 
 ファイルがeager loadingされる順序は未定義です。
 
-たとえば`Zeitwerk`という定数を定義すると、Railsはアプリケーションの自動読み込みモードにかかわらず`Zeitwerk::Loader.eager_load_all`を呼び出します。Zeitwerkが管理する依存はこのようにしてeager loadされます。
-
+eager loading中に、Railsは`Zeitwerk::Loader.eager_load_all`を呼び出します。これはすべてのZeitwerkが管理している依存gemもeager loadされていることを保証します。
 
 STI（単一テーブル継承）
 ------------------------


### PR DESCRIPTION
autoloading_and_reloading_constants.md の翻訳を改善しました。
このPRでは3点の改善を行いました。


# 「また、Railsエンジンは〜」の訳を修正

原文は次のようになっています。

> Also, engines can push in body of the engine class and in their own `config/environments/*.rb`.

この文は、言葉を補うと次のように解釈できると思います。

> Also, engines can push (autoload paths が省略されている)
>  (in body of the engine class) ここでひとまとまり
>  and
>  (in their own `config/environments/*.rb`).  ここでもひとまとまり

そのため、この解釈をもとに日本語訳にしました。

なお、この文は2箇所に同じ文が出てきていたため、両方を同様に修正しました。原文でも同様に2箇所で現れていました。

## 解釈の裏付け

"body of the engine class"でautoload pathsをpushできることは、Rails EngineのAPI documentで言及されているのが確認できました。
https://api.rubyonrails.org/classes/Rails/Engine.html

> Like railties, engines can access a config object which contains configuration shared by all railties and the application. Additionally, each engine can access autoload_paths, eager_load_paths and autoload_once_paths settings which are scoped to that engine.
> 
> ```ruby
> class MyEngine < Rails::Engine
>   # Add a load path for this specific Engine
>   config.autoload_paths << File.expand_path("lib/some/path", __dir__)
> 
>   initializer "my_engine.add_middleware" do |app|
>     app.middleware.use MyEngine::Middleware
>   end
> end
> ```

エンジンの`config/environments/*.rb`を使えることが明記されているドキュメントは少し探した感じだと見当たりませんでしたが、実際に手元でrails engineを作って`config/environments/*.rb`に`autoload_paths`の設定が書けることは確認できました ✅ 


# 不要な`$LOAD_PATH`の項目を削除


`$LOAD_PATH`の項目が重複してしまっていたため、片方を削除しました。2つあるものの文章に少し差分があったため、git logで翻訳の日付が古かったほうを削除しました。
原文と同じ順序で章が並ぶようになっています。


なお別の問題として、`{#load_path}`とanchorを設定している部分がうまく動いていないようです。

日本語版:
![Screen Shot 2022-05-19 at 1 04 59](https://user-images.githubusercontent.com/4361134/169089770-c38bc1e5-be38-4110-a4eb-60000b62cce9.png)

英語版:
![Screen Shot 2022-05-19 at 1 05 25](https://user-images.githubusercontent.com/4361134/169089778-d351e5e0-258b-463c-988e-455d9d03975c.png)

これは直し方がわからなかったので、そのままにしてあります。 🙏 


# 「たとえば`Zeitwerk`という定数を定義すると〜」の訳を修正

ここの翻訳も気になったので修正しました。

原文は次のようになっています。

> During eager loading, Rails invokes `Zeitwerk::Loader.eager_load_all`. That ensures all gem dependencies managed by Zeitwerk are eager-loaded too.


翻訳とだいぶ文が違うので気になって調べたところ、どうやら翻訳は https://github.com/rails/rails/commit/9b76e93fea50b2b982993a2211334ccd1adf7c52 のコミットの前の文を翻訳しているようでした。
そのため、翻訳を直すついでに、最新の英語を参考に修正しました。