### PR TITLE
config.filter_parameters の訳文から欠けている部分を追加

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -150,7 +150,15 @@ developmentモードで発生したエラーのレスポンスで用いられる
 
 #### `config.filter_parameters`
 
-パスワードやクレジットカード番号など、ログに出力したくないパラメータをフィルタで除外するのに用います。デフォルトのRailsでは`config/initializers/filter_parameter_logging.rb`に`Rails.application.config.filter_parameters += [:password]`を追加することでパスワードをフィルタで除外します。パラメータのフィルタは正規表現の**部分一致**によって行われます（訳注: 他のパラメータ名が誤って部分一致しないようご注意ください）。
+パスワードやクレジットカード番号など、ログに出力したくないパラメータをフィルタで除外するのに用います。また、Active Recordオブジェクトに対して`#inspect`を呼び出した際に、データベースの機密性の高い値をフィルタで除外します。デフォルトのRailsでは`config/initializers/filter_parameter_logging.rb`に以下の記述を追加することでパスワードをフィルタで除外しています。
+
+```ruby
+Rails.application.config.filter_parameters += [
+  :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
+]
+```
+
+パラメータのフィルタは正規表現の**部分一致**によって行われます（訳注: 他のパラメータ名が誤って部分一致しないようご注意ください）。
 
 #### `config.force_ssl`
 


### PR DESCRIPTION
`config.filter_parameters` 項で、Active Recordオブジェクトに `#inspect` した際の記述が欠けていたので追加しました。

原文:
>It also filters out sensitive values of database columns when calling `#inspect` on an Active Record object.

追加した訳:
>また、Active Recordオブジェクトに対して`#inspect`を呼び出した際に、データベースの機密性の高い値をフィルタで除外します。

またデフォルト時の設定が更新されていたのでそちらも原文に合わせました。

原文の全文:
https://github.com/rails/rails/blob/3bcd48f6d8b0d87e02b75d124984895cf28e6f9c/guides/source/configuring.md?plain=1#L253-L267
