### PR TITLE
active_record_querying.mdのリンクの定義漏れを修正

### DIFF
--- a/guides/source/ja/active_record_querying.md
+++ b/guides/source/ja/active_record_querying.md
@@ -2194,6 +2194,8 @@ Order.average("subtotal")
 
 オプションについては、1つ上の[計算](#計算)セクションを参照してください。
 
+[`average`]: https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-average
+
 ### 最小値
 
 テーブルに含まれるフィールドの最小値を得るには、そのテーブルを持つクラスで[`minimum`][]メソッドを呼び出します。このメソッド呼び出しは以下のようになります。


### PR DESCRIPTION
https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-average
へのリンクの定義が漏れていたためにリンクが正しく機能していませんでした。

- 該当箇所：[https://railsguides.jp/active_record_querying.html#平均](https://railsguides.jp/active_record_querying.html#%E5%B9%B3%E5%9D%87)
- 原文：<https://edgeguides.rubyonrails.org/active_record_querying.html#average>
  - ソース：<https://github.com/rails/rails/blob/3fd0f848bda056bda3e09b78c77bc114a09bba55/guides/source/active_record_querying.md?plain=1#L2277-L2289>

| before | after |
| ------ | ----- |
| <img width="652" alt="image" src="https://user-images.githubusercontent.com/46666464/177793511-74fbf122-a05a-411e-990a-4ff88c9fa85c.png"> | <img width="652" alt="image" src="https://user-images.githubusercontent.com/46666464/177793420-f07a1bbc-6aef-4c56-9bf7-49e0d6602356.png"> |
