### PR TITLE
`ActiveRecord::Result#to_hash`から`to_a`への変更漏れを修正

### DIFF
--- a/guides/source/ja/active_record_querying.md
+++ b/guides/source/ja/active_record_querying.md
@@ -1969,7 +1969,7 @@ irb> Customer.find_by_sql("SELECT * FROM customers INNER JOIN orders ON customer
 
 ### `select_all`
 
-`find_by_sql`は[`connection.select_all`][]と深い関係があります。`select_all`は`find_by_sql`と同様、カスタムSQLを用いてデータベースからオブジェクトを取り出しますが、取り出したオブジェクトをインスタンス化しない点が異なります。このメソッドは`ActiveRecord::Result`クラスのインスタンスを1つ返します。このオブジェクトで`to_hash`を呼ぶと、各レコードに対応するハッシュを含む配列を1つ返します。
+`find_by_sql`は[`connection.select_all`][]と深い関係があります。`select_all`は`find_by_sql`と同様、カスタムSQLを用いてデータベースからオブジェクトを取り出しますが、取り出したオブジェクトをインスタンス化しない点が異なります。このメソッドは`ActiveRecord::Result`クラスのインスタンスを1つ返します。このオブジェクトで`to_a`を呼ぶと、各レコードに対応するハッシュを含む配列を1つ返します。
 
 ```
 irb> Customer.connection.select_all("SELECT first_name, created_at FROM customers WHERE id = '1'").to_a


### PR DESCRIPTION
`ActiveRecord::Result#to_hash`は削除されて`to_a`を用いるように原文で変更されていますが、`to_hash`の記述が残っていたので`to_a`に修正しました。

原文では https://github.com/rails/rails/commit/6486f80d3a3448579089fab1c8b7846c09cf87ec にて説明文とサンプルコードの`to_hash`が`to_a`に変更されています。
https://github.com/yasslab/railsguides.jp/commit/9c97bdab0ee38d5ae28119ce0f9d7a579c249852#diff-cc9e4f99049d70eae347d5ca07855bfabf619869e820f1dee97cc8ab10285c64R1950-R1954 にてその変更を含む翻訳の更新を行ったようです。サンプルコードは`to_a`に変更されていますが、説明文は`to_hash`のまま残ってしまっていました。

- 該当箇所： https://railsguides.jp/active_record_querying.html#select-all
  - `このメソッドはActiveRecord::Resultクラスのインスタンスを1つ返します。このオブジェクトでto_hashを呼ぶと、各レコードに対応するハッシュを含む配列を1つ返します。`
- 原文： https://edgeguides.rubyonrails.org/active_record_querying.html#select-all
  - `This method will return an instance of ActiveRecord::Result class and calling to_a on this object would return you an array of hashes where each hash indicates a record.`