### PR TITLE
JSの Syntax Highlight がコードブロックでも反映するようにしたい

### DIFF
--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -61,6 +61,8 @@ HTML
           case code_type
           when "ruby"
             "Ruby"
+          when "js"
+            "Javascript"
           when "sql"
             "SQL"
           when "erb", "html+erb"


### PR DESCRIPTION
close: #1276

## やったこと

JS の Syntax ハイライトが効くようにしたい

<img width="698" alt="Screen Shot 2022-08-24 at 0 43 41" src="https://user-images.githubusercontent.com/6015450/186284296-df44b7a0-9e79-45f0-b270-50a6665c17e1.png">
