### PR TITLE
Markdownリンクを修正

### DIFF
--- a/guides/source/ja/initialization.md
+++ b/guides/source/ja/initialization.md
@@ -551,7 +551,7 @@ end
 最後に実行される`finisher`イニシャライザは、ミドルウェアスタックのビルドなどを行います。
 `railtie`イニシャライザは`Rails::Application`自身で定義されており、`bootstrap`と`finishers`の間に実行されます。
 
-*Note:* Railtieイニシャライザ全体と、[load_config_initializers](configuring.html#using-initializer-files)イニシャライザのインスタンスやそれに関連する`config/initializers`以下のイニシャライザ設定ファイルを混同しないようにしましょう。
+*Note:* Railtieイニシャライザ全体と、[load_config_initializers](configuring.html#イニシャライザファイルを使う)イニシャライザのインスタンスやそれに関連する`config/initializers`以下のイニシャライザ設定ファイルを混同しないようにしましょう。
 
 以上の処理が完了すると、制御は`Rack::Server`に移ります。
 

--- a/guides/source/ja/initialization.md
+++ b/guides/source/ja/initialization.md
@@ -551,7 +551,7 @@ end
 最後に実行される`finisher`イニシャライザは、ミドルウェアスタックのビルドなどを行います。
 `railtie`イニシャライザは`Rails::Application`自身で定義されており、`bootstrap`と`finishers`の間に実行されます。
 
-*Note:* Railtieイニシャライザ全体と、load_config_initializers](configuring.html#using-initializer-files)イニシャライザのインスタンスやそれに関連する`config/initializers`以下のイニシャライザ設定ファイルを混同しないようにしましょう。
+*Note:* Railtieイニシャライザ全体と、[load_config_initializers](configuring.html#using-initializer-files)イニシャライザのインスタンスやそれに関連する`config/initializers`以下のイニシャライザ設定ファイルを混同しないようにしましょう。
 
 以上の処理が完了すると、制御は`Rack::Server`に移ります。
 


### PR DESCRIPTION
https://railsguides.jp/configuring.html#using-initializer-files へのMarkdownリンク先頭の`[`が抜けていたため追加

[guides.rubyonrails.orgの該当箇所](https://guides.rubyonrails.org/initialization.html#railties-lib-rails-application-rb)では正しくリンクが生成されていることを確認済みです。