### PR TITLE
Fix bundle version causing issue to run on heroku

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,4 +156,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   1.17.3
+   2.3.7


### PR DESCRIPTION
## やりたいこと

デプロイをする際に Bundler のバージョンが古いため、エラーになるので、修正を行いたい。