### PR TITLE
Fix bundle version causing issue to run on heroku

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,4 +156,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.3.7
+   2.3.22


### PR DESCRIPTION
## やりたいこと

 Heroku では 2.3.7 でも同様の問題が起きていたので、最新版の Bunbdler に変更した

https://github.com/rubygems/rubygems/issues/5351