### PR TITLE
Edit this page on GitHubの導入

### DIFF
--- a/guides/rails_guides/generator_ja.rb
+++ b/guides/rails_guides/generator_ja.rb
@@ -66,7 +66,8 @@ module RailsGuides
             view:    view,
             layout:  layout,
             edge:    @edge,
-            version: @version
+            version: @version,
+            markdown_file_name: guide
           ).render(body)
 
           warn_about_broken_links(result) if @warnings

--- a/guides/rails_guides/markdown_ja.rb
+++ b/guides/rails_guides/markdown_ja.rb
@@ -3,6 +3,12 @@ require "rails_guides/markdown/renderer_ja"
 
 module RailsGuides
   class MarkdownJa < Markdown
+    def initialize(markdown_file_name:, **hash)
+      @markdown_file_name = markdown_file_name
+
+      super(**hash)
+    end
+
     def render(body)
       @raw_body = body
       extract_raw_header_and_body
@@ -87,7 +93,12 @@ module RailsGuides
         end
       end
 
+      def markdown_path_on_github
+        File.join('https://github.com/yasslab/railsguides.jp/tree/master/guides/source/ja', @markdown_file_name)
+      end
+
       def render_page
+        @view.content_for(:markdown_path_on_github) { markdown_path_on_github }
         @view.content_for(:references) { @references }
         super
       end

--- a/guides/source/ja/layout.html.erb
+++ b/guides/source/ja/layout.html.erb
@@ -187,7 +187,7 @@
           <% end %>
      <% if yield(:markdown_path_on_github).present? %>
       <p style="font-size: 1.1428em">
-        <%= link_to '🖋Edit this page on GitHub', yield(:markdown_path_on_github) %>
+        <%= link_to '🖋Githubで編集を提案', yield(:markdown_path_on_github) %>
       </p>
       <% end %>
 	  <ol class="snsb" style="padding-top: 50px;">

--- a/guides/source/ja/layout.html.erb
+++ b/guides/source/ja/layout.html.erb
@@ -185,7 +185,11 @@
   	      </div>
 	    </div>
           <% end %>
-
+     <% if yield(:markdown_path_on_github).present? %>
+      <p style="font-size: 1.1428em">
+        <%= link_to '🖋Edit this page on GitHub', yield(:markdown_path_on_github) %>
+      </p>
+      <% end %>
 	  <ol class="snsb" style="padding-top: 50px;">
 	    <li style='padding-right: 8px;'><a class="github-button" href="https://github.com/yasslab/railsguides.jp" data-icon="octicon-star" data-show-count="true" aria-label="Star yasslab/railsguides.jp on GitHub">Star</a></li>
 	    <li style='padding-right: 8px;'><a href="https://b.hatena.ne.jp/entry/s/railsguides.jp" class="hatena-bookmark-button" data-hatena-bookmark-title="Ruby on Rails ガイド：体系的に Rails を学ぼう" data-hatena-bookmark-layout="simple-balloon" data-hatena-bookmark-lang="ja" title="このエントリーをはてなブックマークに追加"><img src="https://b.st-hatena.com/images/entry-button/button-only@2x.png" alt="このエントリーをはてなブックマークに追加" width="20" height="20" style="border: none;" /></a><script type="text/javascript" src="https://b.st-hatena.com/js/bookmark_button.js" charset="utf-8" async="async"></script></li>


### PR DESCRIPTION
## 概要
（かなり前のIssueだったので需要があるかわかりませんが… 🙏 ）
該当するmarkdownファイルのリポジトリに遷移するリンクを動的に生成しました。

![スクリーンショット 2022-09-23 12 42 21](https://user-images.githubusercontent.com/38002468/191888210-616fd103-8262-405a-8e71-4e9cd8207988.png)

## 補足
トップページはmarkdownから生成されていないので対象外としています。

## 動作確認方法

```sh
$ bundle exec rake assets:precompile
$ bundle exec jekyll server
```

上記コマンドを実行した上、適当なページの下部（例：[Active Record マイグレーション](http://127.0.0.1:4000/active_record_migrations.html#supporters)）の「Edit this page on Github」のリンクから該当するMarkdownのファイルに遷移できることをご確認下さい。


## 関連のあるIssue
#780 