### PR TITLE
Update initialization.md

### DIFF
--- a/guides/source/ja/initialization.md
+++ b/guides/source/ja/initialization.md
@@ -501,7 +501,6 @@ require "rails"
   action_mailbox/engine
   action_text/engine
   rails/test_unit/railtie
-  sprockets/railtie
 ).each do |railtie|
   begin
     require railtie


### PR DESCRIPTION
sprockets は optional となり、`railties/lib/rails/all.rb` からは削除されているようなので修正します。 https://github.com/rails/rails/blob/main/railties/lib/rails/all.rb#L17

削除時のコミットは以下です。
https://github.com/rails/rails/commit/fb1ab3460a676ce7def0819c2e92289ef2dcbe3b#diff-b93579f6233ade0fc8e05d8b79cbe745b7546465310477554f4e268e994c5e08L1673

英語ドキュメントの方は修正済みでした。
https://github.com/rails/rails/blob/main/guides/source/initialization.md#railtieslibrailsallrb