### PR TITLE
rbの指定にもシンタックスハイライトが適用されるように更新した

### DIFF
--- a/guides/rails_guides/markdown/renderer.rb
+++ b/guides/rails_guides/markdown/renderer.rb
@@ -59,7 +59,7 @@ HTML
 
         def brush_for(code_type)
           case code_type
-          when "ruby"
+          when "ruby", "rb"
             "Ruby"
           when "js"
             "Javascript"


### PR DESCRIPTION
### やったこと
コードブロックの言語指定が`rb`の場合はシンタックスハイライトが適用されていなかったので、適用されるように更新しました。

🔽変更後表示例
![スクリーンショット 2022-10-05 11 46 12](https://user-images.githubusercontent.com/41533420/193972443-6d80924f-1fd9-40b1-8b58-283c9f614712.png)
