### PR TITLE
支援・協賛バナーをロゴ＋テキストの表示に対応させた

### DIFF
--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -1191,6 +1191,7 @@ table td, table th { padding: 9px 10px; text-align: left; }
 .bnr-pro-team,.footer-bnr {
   display:flex;
   justify-content:space-between;
+  align-items: center;
   .bnr-item {
     padding: 10px;
   }
@@ -1209,6 +1210,15 @@ table td, table th { padding: 9px 10px; text-align: left; }
 .footer-bnr img.border {
   border:1px solid #e8e8e8;
   box-sizing: border-box;
+}
+.bnr-item-text {
+  padding: 20px;
+  h4{
+    margin: 0 0 0.5em;
+  }
+  p {
+    margin: 0;
+  }
 }
 
 /* code block style */

--- a/guides/source/ja/layout.html.erb
+++ b/guides/source/ja/layout.html.erb
@@ -180,16 +180,34 @@
 	      Railsガイドは下記のサポーターから継続的な支援を受けています。Railsガイドへの支援・協賛にご興味あれば info@yasslab.jp までお問い合わせください。
 	    </p>
 	    <div class="footer-bnr">
-  	      <div class="bnr-item">
-    		<a href="https://www.carbonads.net/open-source?utm_source=railsguide&utm_medium=banner&utm_campaign=supporter" target="_blank" rel="noopener">
-		  <img class="border lazyload" alt="Advertising For Open Source Projects | Carbon Ads" src="/images/spinner.svg" data-src="/images/logos/carbon.gif" loading="lazy" />
-		</a>
-  	      </div>
+        <div class="bnr-item">
+          <a href="https://www.carbonads.net/open-source?utm_source=railsguide&utm_medium=banner&utm_campaign=supporter" target="_blank" rel="noopener">
+            <img class="border lazyload" alt="Advertising For Open Source Projects | Carbon Ads" src="/images/spinner.svg" data-src="/images/logos/carbon.gif" loading="lazy" />
+          </a>
+        </div>
 
-  	      <div class="bnr-item">
-    		<a href="https://railsguides.jp/contact"><img alt="協賛募集" src="/images/spinner.svg" data-src="/images/logos/bnr-kyosan.gif" loading="lazy" class="lazyload" /></a>
-  	      </div>
+        <div class="bnr-item">
+          <a href="https://railsguides.jp/contact"><img alt="協賛募集" src="/images/spinner.svg" data-src="/images/logos/bnr-kyosan.gif" loading="lazy" class="lazyload" /></a>
+        </div>
 	    </div>
+<%
+=begin%>
+  正方形ロゴ + テキストの表示用（サンプルとしてYassLabで作成しています）
+<%
+=end%>
+      <div class="footer-bnr">
+        <div class="bnr-item">
+          <a href="https://yasslab.jp/" target="_blank" rel="noopener">
+            <img src="/images/logos/yasslab_square.png" alt="YassLab" />
+          </a>
+        </div>
+
+        <div class="bnr-item-text">
+          <h4><a href="https://yasslab.jp/" target="_blank" rel="noopener">YassLab 株式会社</a></h4>
+            <p><a href="https://railstutorial.jp/" target="_blank" rel="noopener">Ruby on Railsチュートリアル</a>や<a href="/">Ruby on Railsガイド</a>を運営しているチームです。全国200カ所以上ある子供のためのプログラミング道場「CoderDojo」のWebサイト（<a href="https://coderdojo.jp/" target="_blank" rel="noopener">coderdojo-japan/coderdojo.jp</a>）も開発しています。（約140文字）</P>
+        </div>
+      </div>
+
           <% end %>
 	  <ol class="snsb" style="padding-top: 50px;">
 	    <li style='padding-right: 8px;'><a class="github-button" href="https://github.com/yasslab/railsguides.jp" data-icon="octicon-star" data-show-count="true" aria-label="Star yasslab/railsguides.jp on GitHub">Star</a></li>

--- a/guides/source/ja/layout.html.erb
+++ b/guides/source/ja/layout.html.erb
@@ -192,8 +192,6 @@
 <%
 =begin%>
   正方形ロゴ + テキストの表示用（サンプルとしてYassLabで作成しています）
-<%
-=end%>
       <div class="footer-bnr">
         <div class="bnr-item">
           <a href="https://yasslab.jp/" target="_blank" rel="noopener">
@@ -206,6 +204,8 @@
             <p><a href="https://railstutorial.jp/" target="_blank" rel="noopener">Ruby on Railsチュートリアル</a>や<a href="/">Ruby on Railsガイド</a>を運営しているチームです。全国200カ所以上ある子供のためのプログラミング道場「CoderDojo」のWebサイト（<a href="https://coderdojo.jp/" target="_blank" rel="noopener">coderdojo-japan/coderdojo.jp</a>）も開発しています。（約140文字）</P>
         </div>
       </div>
+<%
+=end%>
 
           <% end %>
 	  <ol class="snsb" style="padding-top: 50px;">


### PR DESCRIPTION
### やったこと

- 支援支援・協賛セクションの表示をロゴ＋テキストの表示に対応させました。
- 基本的に #1292 #1294 と同様の更新ですが、変更箇所をなるべく少なくしました

### 📝メモ

- テキスト内リンクの下線については別途対応する予定です🙏
- 見比べ易いように一旦両方表示させていますが、マージする前にロゴ＋テキスト表示は一旦コメントアウトで非表示にします。
- 前回削除した`.bnr-pro-team` は使用箇所があったため残しています🙇‍♀️

> CSSで現在使われていない.bnr-pro-team をコメントアウトしました。