### PR TITLE
リンクにオンマウスした時の下線を振る舞いを統一

### DIFF
--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -192,6 +192,7 @@ img {
   &:hover {
     color: #ffeded;
     background: #da6258;
+    text-decoration: none;
   }
 }
 
@@ -455,10 +456,11 @@ aside#toppage {
 
 a, a code {
   color: $main-dark;
-  text-decoration: underline;
+  text-decoration: none;
 }
 a:hover {
   color: $main-light;
+  text-decoration: underline;
 }
 
 #mainCol .anchorlink, #mainCol .anchorlink code {color: $gray-dark;}
@@ -522,7 +524,7 @@ h3 a, h4 a, h5 a, h6 a {
 
 .guides-index:hover .guides-index-item, .guides-index .guides-index-item:hover {
   background-position: right -81px;
-  text-decoration: underline !important;
+  text-decoration: none !important;
 }
 
 @media screen and (min-width: 481px) {

--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -524,7 +524,7 @@ h3 a, h4 a, h5 a, h6 a {
 
 .guides-index:hover .guides-index-item, .guides-index .guides-index-item:hover {
   background-position: right -81px;
-  text-decoration: none !important;
+  text-decoration: none;
 }
 
 @media screen and (min-width: 481px) {


### PR DESCRIPTION
### やったこと
リンクにオンマウスした時の下線を振る舞いを統一しました

- テキスト
  - 通常: アンダーラインなし
  - オンマウス: アンダーラインあり
- テキスト以外
  - 通常 / オンマウス: アンダーラインなし

### メモ
- TOPのお知らせ部分は、通常の状態で`text-decoration: underline;`の指定がされていたので、そのままにしています
![スクリーンショット 2022-10-07 15 12 52](https://user-images.githubusercontent.com/41533420/194480169-697d682a-33fc-4993-826c-26b6cfb59588.png)
- サイドバー目次への変更は加えていません