### PR TITLE
支援・協賛のバナーに id を追加

### DIFF
--- a/guides/source/ja/layout.html.erb
+++ b/guides/source/ja/layout.html.erb
@@ -178,28 +178,27 @@
 	    <p>
 	      Railsガイドは下記のサポーターから継続的な支援を受けています。Railsガイドへの支援・協賛にご興味あれば info@yasslab.jp までお問い合わせください。
 	    </p>
-	    <div class="footer-bnr">
-        <div class="bnr-item">
+      <div class="footer-bnr">
+        <div class="bnr-item" id='footer-carbonads'>
           <a href="https://www.carbonads.net/open-source?utm_source=railsguide&utm_medium=banner&utm_campaign=supporter" target="_blank" rel="noopener">
             <img class="border lazyload" alt="Advertising For Open Source Projects | Carbon Ads" src="/images/spinner.svg" data-src="/images/logos/carbon.gif" loading="lazy" />
           </a>
         </div>
-
-  	      <div class="bnr-item">
-    		<a href="https://railsguides.jp/sponsors"><img alt="協賛プラン" src="/images/spinner.svg" data-src="/images/logos/bnr-kyosan.gif" loading="lazy" class="lazyload" /></a>
-  	      </div>
-	    </div>
+        <div class="bnr-item" id='footer-sponsors'>
+          <a href="https://railsguides.jp/sponsors"><img alt="協賛プラン" src="/images/spinner.svg" data-src="/images/logos/bnr-kyosan.gif" loading="lazy" class="lazyload" /></a>
+        </div>
+      </div>
 <%
 =begin%>
   正方形ロゴ + テキストの表示用（サンプルとしてYassLabで作成しています）
       <div class="footer-bnr">
-        <div class="bnr-item">
+        <div class="bnr-item" id='footer-yasslab'>
           <a href="https://yasslab.jp/" target="_blank" rel="noopener">
             <img src="/images/logos/yasslab_square.png" alt="YassLab" />
           </a>
         </div>
 
-        <div class="bnr-item-text">
+        <div class="bnr-item-text id='footer-yasslab-text'">
           <h4><a href="https://yasslab.jp/" target="_blank" rel="noopener">YassLab 株式会社</a></h4>
             <p><a href="https://railstutorial.jp/" target="_blank" rel="noopener">Ruby on Railsチュートリアル</a>や<a href="/">Ruby on Railsガイド</a>を運営しているチームです。全国200カ所以上ある子供のためのプログラミング道場「CoderDojo」のWebサイト（<a href="https://coderdojo.jp/" target="_blank" rel="noopener">coderdojo-japan/coderdojo.jp</a>）も開発しています。（約140文字）</P>
         </div>


### PR DESCRIPTION
## やったこと
- 支援・協賛を識別するために、支援・協賛のバナーに id を追加しました