### PR TITLE
協賛バナーをボーダーで囲った

### DIFF
--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -1163,6 +1163,10 @@ table td, table th { padding: 9px 10px; text-align: left; }
   display:flex;
   justify-content:space-between;
   align-items: center;
+  border-radius: 3px;
+  border: solid #eee 2px;
+  margin-bottom: 1.2rem;
+  transition: all .2s;
   .bnr-item {
     padding: 10px;
   }

--- a/guides/assets/stylesheets/main.scss
+++ b/guides/assets/stylesheets/main.scss
@@ -1159,7 +1159,7 @@ table td, table th { padding: 9px 10px; text-align: left; }
 }
 /* banner
 --------------------------------------- */
-.bnr-pro-team,.footer-bnr {
+.footer-bnr {
   display:flex;
   justify-content:space-between;
   align-items: center;
@@ -1171,15 +1171,39 @@ table td, table th { padding: 9px 10px; text-align: left; }
     padding: 10px;
   }
   img {
+    max-width: 130px;
+    &:hover {
+      opacity: 0.8;
+    }
+  }
+}
+
+.bnr-item-text {
+  padding: 20px;
+  h4{
+    margin: 0 0 0.5em;
+  }
+  p {
+    margin: 0;
+    font-size: 0.95em;
+  }
+}
+
+.bnr-pro-team {
+  display:flex;
+  justify-content:space-between;
+  align-items: center;
+  .bnr-item {
+    padding: 10px;
+  }
+  img {
     max-width: 100%;
     &:hover {
       opacity: 0.8;
     }
   }
 }
-.footer-bnr img {
-  max-width: 130px;
-}
+
 @media screen and (max-width: 630px) {
   .footer-bnr, .bnr-pro-team {
     flex-direction:column;
@@ -1189,20 +1213,6 @@ table td, table th { padding: 9px 10px; text-align: left; }
     img {
       max-width: 250px;
     }
-  }
-}
-.footer-bnr img.border {
-  border:1px solid #e8e8e8;
-  box-sizing: border-box;
-}
-.bnr-item-text {
-  padding: 20px;
-  h4{
-    margin: 0 0 0.5em;
-  }
-  p {
-    margin: 0;
-    font-size: 0.95em;
   }
 }
 


### PR DESCRIPTION
### やったこと
- 協賛バナーを企業ごとにボーダーで囲みました（note記事へのリンクを参考に薄いグレーを使用）
- 共通で指定されていた`.footer-bnr`と`.bnr-pro-team`は、表示デザインがかなり異なってきたため分割しました
- 微調整

🔽協賛バナー部分変更後
![スクリーンショット 2022-11-21 14 39 12](https://user-images.githubusercontent.com/41533420/202980033-5b6e3c0b-9bc2-4f02-a056-1a8301011b20.png)

🔽`.bnr-pro-team`適用部分（表示には変更なし）
![スクリーンショット 2022-11-21 14 40 42](https://user-images.githubusercontent.com/41533420/202980172-f9759ddc-b841-4648-9e50-bad6572d1108.png)

### 別途やりたいこと
現状に合わなくなったので、`.bnr-pro-team`のクラス名を変更したい
