### PR TITLE
見出しの誤訳を修正

### DIFF
--- a/guides/source/ja/active_record_migrations.md
+++ b/guides/source/ja/active_record_migrations.md
@@ -370,7 +370,7 @@ end
 
 [`change_table`]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-change_table
 
-### カラム名を変更する
+### カラムを変更する
 
 マイグレーションでは、`remove_column`や`add_column`に加えて[`change_column`][]メソッドも利用できます。
 


### PR DESCRIPTION
英語版における原文は `Changing Columns` 。
カラム名の変更は直前の項で既に扱っており、
この項で扱っているのはカラムの型や制約の変更である。
見出しの翻訳が不適切であると判断し、修正した。