### PR TITLE
6.1バージョンTOPから Carbon Ads を削除

### DIFF
--- a/guides/source/ja/index.html.erb
+++ b/guides/source/ja/index.html.erb
@@ -55,7 +55,6 @@ Ruby on Rails ガイド：体系的に Rails を学ぼう
 </div>
 <% end %>
 
-<script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CE7ITK7L&placement=railsguidesjp" id="_carbonads_js"></script>
 <dl style='padding-top: 15px;'>
   <dd class="work-in-progress">このアイコンが付いているガイドは現在作業中 (WIP: Work In Progress) です。作業中のガイドはそれなりに有用ではありますが、不完全な情報やエラーが含まれている可能性があります。</dd>
 </dl>


### PR DESCRIPTION
過去バージョンのTOPページ表示を統一するため、Carbon Ads を削除しました✂️