### PR TITLE
7_0_stableのasset_pipeline.md訳文を更新

### DIFF
--- a/guides/source/asset_pipeline.md
+++ b/guides/source/asset_pipeline.md
@@ -27,10 +27,10 @@ from other gems.
 The asset pipeline is implemented by the
 [sprockets-rails](https://github.com/rails/sprockets-rails) gem,
 and is enabled by default. You can disable it while creating a new application by
-passing the `--skip-sprockets` option.
+passing the `--skip-asset-pipeline` option.
 
 ```bash
-$ rails new appname --skip-sprockets
+$ rails new appname --skip-asset-pipeline
 ```
 
 Rails can easily work with Sass by adding the [`sassc-rails`](https://github.com/sass/sassc-rails)
@@ -41,8 +41,8 @@ gem 'sassc-rails'
 ```
 
 To set asset compression methods, set the appropriate configuration options
-in `production.rb` - `config.assets.css_compressor` for your CSS and
-`config.assets.js_compressor` for your JavaScript:
+in `production.rb` - [`config.assets.css_compressor`][] for your CSS and
+[`config.assets.js_compressor`][] for your JavaScript:
 
 ```ruby
 config.assets.css_compressor = :yui
@@ -51,6 +51,9 @@ config.assets.js_compressor = :terser
 
 NOTE: The `sassc-rails` gem is automatically used for CSS compression if included
 in the `Gemfile` and no `config.assets.css_compressor` option is set.
+
+[`config.assets.css_compressor`]: configuring.html#config-assets-css-compressor
+[`config.assets.js_compressor`]: configuring.html#config-assets-js-compressor
 
 ### Main Features
 
@@ -134,12 +137,14 @@ that filenames are consistent based on their content.
 
 Fingerprinting is enabled by default for both the development and production
 environments. You can enable or disable it in your configuration through the
-`config.assets.digest` option.
+[`config.assets.digest`][] option.
 
 More reading:
 
 * [Optimize caching](https://developers.google.com/speed/docs/insights/LeverageBrowserCaching)
 * [Revving Filenames: don't use querystring](http://www.stevesouders.com/blog/2008/08/23/revving-filenames-dont-use-querystring/)
+
+[`config.assets.digest`]: configuring.html#config-assets-digest
 
 
 How to Use the Asset Pipeline
@@ -152,12 +157,14 @@ directory. Files in this directory are served by the Sprockets middleware.
 
 Assets can still be placed in the `public` hierarchy. Any assets under `public`
 will be served as static files by the application or web server when
-`config.public_file_server.enabled` is set to true. You should use `app/assets` for
+[`config.public_file_server.enabled`][] is set to true. You should use `app/assets` for
 files that must undergo some pre-processing before they are served.
 
 In production, Rails precompiles these files to `public/assets` by default. The
 precompiled copies are then served as static assets by the web server. The files
 in `app/assets` are never served directly in production.
+
+[`config.public_file_server.enabled`]: configuring.html#config-public-file-server-enabled
 
 ### Controller Specific Assets
 
@@ -248,7 +255,7 @@ is referenced as:
 ```
 
 You can view the search path by inspecting
-`Rails.application.config.assets.paths` in the Rails console.
+[`Rails.application.config.assets.paths`][`config.assets.paths`] in the Rails console.
 
 Besides the standard `assets/*` paths, additional (fully qualified) paths can be
 added to the pipeline in `config/initializers/assets.rb`. For example:
@@ -264,6 +271,8 @@ corresponding paths in `lib` and `vendor`.
 It is important to note that files you want to reference outside a manifest must
 be added to the precompile array or they will not be available in the production
 environment.
+
+[`config.assets.paths`]: configuring.html#config-assets-paths
 
 #### Using Index Files
 
@@ -319,7 +328,7 @@ Alternatively, a request for a file with an SHA256 hash such as
 is treated the same way. How these hashes are generated is covered in the [In
 Production](#in-production) section later on in this guide.
 
-Sprockets will also look through the paths specified in `config.assets.paths`,
+Sprockets will also look through the paths specified in [`config.assets.paths`][],
 which includes the standard application paths and any paths added by Rails
 engines.
 
@@ -444,7 +453,7 @@ which contains these lines:
 ```
 
 Rails creates `app/assets/stylesheets/application.css` regardless of whether the
-`--skip-sprockets` option is used when creating a new Rails application. This is
+`--skip-asset-pipeline` option is used when creating a new Rails application. This is
 so you can easily add asset pipelining later if you like.
 
 The directives that work in JavaScript files also work in stylesheets
@@ -598,7 +607,7 @@ NOTE: with the Asset Pipeline the `:cache` and `:concat` options aren't used
 anymore, delete these options from the `javascript_include_tag` and
 `stylesheet_link_tag`.
 
-The fingerprinting behavior is controlled by the `config.assets.digest`
+The fingerprinting behavior is controlled by the [`config.assets.digest`][]
 initialization option (which defaults to `true`).
 
 NOTE: Under normal circumstances the default `config.assets.digest` option
@@ -611,7 +620,7 @@ content changes.
 Rails comes bundled with a command to compile the asset manifests and other
 files in the pipeline.
 
-Compiled assets are written to the location specified in `config.assets.prefix`.
+Compiled assets are written to the location specified in [`config.assets.prefix`][].
 By default, this is the `/assets` directory.
 
 You can call this command on the server during deployment to create compiled
@@ -682,6 +691,8 @@ The default location for the manifest is the root of the location specified in
 NOTE: If there are missing precompiled files in production you will get a
 `Sprockets::Helpers::RailsHelper::AssetPaths::AssetNotPrecompiledError`
 exception indicating the name of the missing file(s).
+
+[`config.assets.prefix`]: configuring.html#config-assets-prefix
 
 #### Far-future Expires Header
 
@@ -820,7 +831,7 @@ To set up your CDN you have to have your application running in production on
 the internet at a publicly available URL, for example `example.com`. Next
 you'll need to sign up for a CDN service from a cloud hosting provider. When you
 do this you need to configure the "origin" of the CDN to point back at your
-website `example.com`, check your provider for documentation on configuring the
+website `example.com`. Check your provider for documentation on configuring the
 origin server.
 
 The CDN you provisioned should give you a custom subdomain for your application
@@ -829,7 +840,7 @@ valid CDN provider at the time of this writing). Now that you have configured
 your CDN server, you need to tell browsers to use your CDN to grab assets
 instead of your Rails server directly. You can do this by configuring Rails to
 set your CDN as the asset host instead of using a relative path. To set your
-asset host in Rails, you need to set `config.asset_host` in
+asset host in Rails, you need to set [`config.asset_host`][] in
 `config/environments/production.rb`:
 
 ```ruby
@@ -854,47 +865,46 @@ config.asset_host = ENV['CDN_HOST']
 NOTE: You would need to set `CDN_HOST` on your server to `mycdnsubdomain
 .fictional-cdn.com` for this to work.
 
-Once you have configured your server and your CDN when you serve a webpage that
-has an asset:
+Once you have configured your server and your CDN, asset paths from helpers such
+as:
 
 ```erb
 <%= asset_path('smile.png') %>
 ```
 
-Instead of returning a path such as `/assets/smile.png` (digests are left out
-for readability). The URL generated will have the full path to your CDN.
+Will be rendered as full CDN URLs like `http://mycdnsubdomain.fictional-cdn.com/assets/smile.png`
+(digest omitted for readability).
 
-```
-http://mycdnsubdomain.fictional-cdn.com/assets/smile.png
-```
-
-If the CDN has a copy of `smile.png` it will serve it to the browser and your
-server doesn't even know it was requested. If the CDN does not have a copy it
-will try to find it at the "origin" `example.com/assets/smile.png` and then store
+If the CDN has a copy of `smile.png`, it will serve it to the browser, and your
+server doesn't even know it was requested. If the CDN does not have a copy, it
+will try to find it at the "origin" `example.com/assets/smile.png`, and then store
 it for future use.
 
 If you want to serve only some assets from your CDN, you can use custom `:host`
 option your asset helper, which overwrites value set in
-`config.action_controller.asset_host`.
+[`config.action_controller.asset_host`][].
 
 ```erb
 <%= asset_path 'image.png', host: 'mycdnsubdomain.fictional-cdn.com' %>
 ```
 
+[`config.action_controller.asset_host`]: configuring.html#config-action-controller-asset-host
+[`config.asset_host`]: configuring.html#config-asset-host
+
 #### Customize CDN Caching Behavior
 
 A CDN works by caching content. If the CDN has stale or bad content, then it is
 hurting rather than helping your application. The purpose of this section is to
-describe general caching behavior of most CDNs, your specific provider may
+describe general caching behavior of most CDNs. Your specific provider may
 behave slightly differently.
 
 ##### CDN Request Caching
 
-While a CDN is described as being good for caching assets, in reality caches the
+While a CDN is described as being good for caching assets, it actually caches the
 entire request. This includes the body of the asset as well as any headers. The
-most important one being `Cache-Control` which tells the CDN (and web browsers)
+most important one being `Cache-Control`, which tells the CDN (and web browsers)
 how to cache contents. This means that if someone requests an asset that does
-not exist `/assets/i-dont-exist.png` and your Rails application returns a 404,
+not exist, such as `/assets/i-dont-exist.png`, and your Rails application returns a 404,
 then your CDN will likely cache the 404 page if a valid `Cache-Control` header
 is present.
 
@@ -919,7 +929,7 @@ Content-Length: 126560
 Via: 1.1 vegur
 ```
 
-Versus the CDN copy.
+Versus the CDN copy:
 
 ```bash
 $ curl -I http://mycdnsubdomain.fictional-cdn.com/application-
@@ -948,16 +958,14 @@ such as `X-Cache` or for any additional headers they may add.
 
 ##### CDNs and the Cache-Control Header
 
-The [cache control
-header](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9) is a W3C
-specification that describes how a request can be cached. When no CDN is used, a
+The [`Cache-Control`][] header describes how a request can be cached. When no CDN is used, a
 browser will use this information to cache contents. This is very helpful for
 assets that are not modified so that a browser does not need to re-download a
 website's CSS or JavaScript on every request. Generally we want our Rails server
-to tell our CDN (and browser) that the asset is "public", that means any cache
+to tell our CDN (and browser) that the asset is "public". That means any cache
 can store the request. Also we commonly want to set `max-age` which is how long
 the cache will store the object before invalidating the cache. The `max-age`
-value is set to seconds with a maximum possible value of `31536000` which is one
+value is set to seconds with a maximum possible value of `31536000`, which is one
 year. You can do this in your Rails application by setting
 
 ```ruby
@@ -968,9 +976,11 @@ config.public_file_server.headers = {
 
 Now when your application serves an asset in production, the CDN will store the
 asset for up to a year. Since most CDNs also cache headers of the request, this
-`Cache-Control` will be passed along to all future browsers seeking this asset,
-the browser then knows that it can store this asset for a very long time before
+`Cache-Control` will be passed along to all future browsers seeking this asset.
+The browser then knows that it can store this asset for a very long time before
 needing to re-request it.
+
+[`Cache-Control`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
 
 ##### CDNs and URL-based Cache Invalidation
 
@@ -1026,7 +1036,7 @@ Possible options for JavaScript compression are `:terser`, `:closure` and
 
 Take the `terser` gem, for example.
 This gem wraps [Terser](https://github.com/terser/terser) (written for
-NodeJS) in Ruby. It compresses your code by removing white space and comments,
+Node.js) in Ruby. It compresses your code by removing white space and comments,
 shortening local variable names, and performing other micro-optimizations such
 as changing `if` and `else` statements to ternary operators where possible.
 
@@ -1040,7 +1050,7 @@ NOTE: You will need an [ExecJS](https://github.com/rails/execjs#readme)
 supported runtime in order to use `terser`. If you are using macOS or
 Windows you have a JavaScript runtime installed in your operating system.
 
-### GZipping your assets
+### GZipping Your Assets
 
 By default, gzipped version of compiled assets will be generated, along with
 the non-gzipped version of assets. Gzipped assets help reduce the transmission


### PR DESCRIPTION
* https://github.com/rails/rails/commit/afc56721bf790991014002edbeeb7e89a4edf289

## 注意

現状の7-0-stableブランチの英語版asset_pipeline.mdは、6.x時代の記述が多く残っていて、そこに7.xの情報が半端に反映されている状態です。

つなぎとして、以下の追記をしたうえで現状の7-0-stableをキャッチアップする形にしました。

```md
NOTE: 英語版ガイドは現在[#47012](https://github.com/rails/rails/pull/47012)で大幅な更新が進行中です。現状の7-0-stableブランチの英語版ガイドは多くがRails 6時代のものになっていますが、英語版が更新されるまでは現状に即した訳文としています。ご了承ください。
```

```md
NOTE: sassc-rails gemで使われている[libsass](https://sass-lang.com/libsass)は現在非推奨です。
```

```md
Railsに同梱されている turbolinks gem（訳注: 本パラグラフおよび以下のサンプルは、実際には[`turbo-rails`](https://github.com/hotwired/turbo-rails) gem向けの記述です）を利用している場合、`'data-turbo-track'`オプションが利用できます。これはアセットが更新されてページに読み込まれたかどうかをTurboがチェックします。
```

現在英語版は https://github.com/rails/rails/pull/47012 で大幅な書き換えが進行中です。最終的にはこれに沿うのがベストだと思いますが、もしかするとこの更新版は7-1-stableにしか入らないかもしれません。

これをマージすべきか、それとも[#47012](https://github.com/rails/rails/pull/47012)のマージを待つべきか決めたいと思います。