### PR TITLE
config.cache_classesの内容を微修正

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -164,7 +164,7 @@ Railsが定数を自動読み込みするパスの配列を渡せます。`confi
 
 #### `config.cache_classes`
 
-アプリケーションのクラスやモジュールをリクエストごとに再読み込みするか（=キャッシュしないかどうか）どうかを指定します。`config.cache_classes`のデフォルト値は、developmentモードでは`false`なのでコードの更新がすぐ反映され、productionモードの場合は`true`なので高速に動作します。testモードでは、spring gemがインストールされている場合はデフォルトで`false`、そうでない場合は`true`になります。
+アプリケーションのクラスやモジュールをリクエストごとに再読み込みするかどうかを指定します。キャッシュを有効にすると(`true`)、再読み込みは発生しません。`config.cache_classes`のデフォルト値は、developmentモードでは`false`なのでコードの更新がすぐ反映され、productionモードの場合は`true`なので高速に動作します。testモードでは、spring gemがインストールされている場合はデフォルトで`false`、そうでない場合は`true`になります。
 
 #### `config.beginning_of_week`
 


### PR DESCRIPTION
「再読み込みするか（=キャッシュしないかどうか）どうかを指定します」という説明だと、`true`の時にキャッシュせずに再読み込みするように読めてしまったので、英語版を参考にしながら`true`設定時の挙動がわかりやすくなるように一文足してみました。

> 3.2.6 config.cache_classes
> 
> Controls whether or not application classes and modules should be reloaded if they change. When the cache is enabled (true), reloading will not occur. Defaults to false in the development environment, and true in production. In the test environment, the default is false if Spring is installed, true otherwise.

ref: https://guides.rubyonrails.org/configuring.html#config-cache-classes