### PR TITLE
RailsアップグレードガイドにActiveModel::Errorクラスが追加された節を追加する

### DIFF
--- a/guides/source/ja/upgrading_ruby_on_rails.md
+++ b/guides/source/ja/upgrading_ruby_on_rails.md
@@ -531,6 +531,12 @@ video.preview(resize_to_limit: [100, 100])
 video.preview(resize_to_fill: [100, 100])
 ```
 
+### `ActiveModel::Error` クラスが追加された
+
+エラーが新しく `ActiveModel::Error` クラスのインスタンスになり、APIの変更もあわせて行われました。これらの変更によって、新しくエラーが発生する、または Rails 7.0 で廃止されるため非推奨の警告を出力する場合があります。
+
+この変更とAPIの詳細については[PR](https://github.com/rails/rails/pull/32313)を参照してください。
+
 Rails 5.2からRails 6.0へのアップグレード
 -------------------------------------
 


### PR DESCRIPTION
## やったこと

Railsアップグレードガイドの [3 Rails 6.0からRails 6.1へのアップグレード](https://railsguides.jp/upgrading_ruby_on_rails.html#rails-6-0%E3%81%8B%E3%82%89rails-6-1%E3%81%B8%E3%81%AE%E3%82%A2%E3%83%83%E3%83%97%E3%82%B0%E3%83%AC%E3%83%BC%E3%83%89) の節に、英語版のみに記載されていた [4.7 New ActiveModel::Error class](https://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#new-activemodel-error-class) の内容の追加を提案いたします。

## スクリーンショット

![image](https://user-images.githubusercontent.com/50813295/222907561-04a6cf21-84ed-467e-951a-240ab42a4f97.png)
