### PR TITLE
「トランザクションのコールバック」の注意書きを修正

### DIFF
--- a/guides/source/ja/active_record_callbacks.md
+++ b/guides/source/ja/active_record_callbacks.md
@@ -487,7 +487,7 @@ WARNING: あるトランザクションが完了すると、`after_commit`コー
 
 WARNING: `after_commit`コールバックや`after_rollback`コールバックの中で実行されるコードそのものは、トランザクションで囲まれません。
 
-WARNING: 同一のモデル内で`after_create_commit`と`after_update_commit`を両方用いると、最後に定義したコールバックだけが有効になります。理由は、これらのコールバックが内部で`after_commit`のエイリアスになっていて、最初に定義されたコールバックが同名のメソッドによってオーバーライドされるからです。
+WARNING: 同一のモデル内で同じメソッド名を引数に`after_create_commit`と`after_update_commit`を両方用いると、最後に定義したコールバックだけが有効になります。理由は、これらのコールバックが内部で`after_commit`のエイリアスになっていて、最初に同じメソッド名を引数に定義したコールバックがオーバーライドされるからです。
 
 ```ruby
 class User < ApplicationRecord


### PR DESCRIPTION
原著の"with the same method name"の部分の訳が抜けており、別メソッドでafter_update_commit, after_create_commitを使用してもオーバーライドされるように表記されてしまっていたので訂正です。

https://github.com/rails/rails/blob/a199aaedb8e7b54b14874d33345ba8255a3f589b/activesupport/lib/active_support/callbacks.rb#L317 こちらのmatches?に該当するもののみオーバーライド（remove_duplicates）されるようです。