### PR TITLE
autoloading_and_reloading_constants.mdの訳文を更新

### DIFF
--- a/guides/source/autoloading_and_reloading_constants.md
+++ b/guides/source/autoloading_and_reloading_constants.md
@@ -320,13 +320,15 @@ Eager Loading
 
 In production-like environments it is generally better to load all the application code when the application boots. Eager loading puts everything in memory ready to serve requests right away, and it is also [CoW](https://en.wikipedia.org/wiki/Copy-on-write)-friendly.
 
-Eager loading is controlled by the flag [`config.eager_load`][], which is enabled by default in `production` mode.
+Eager loading is controlled by the flag [`config.eager_load`][], which is disabled by default in all environments except `production`. When a Rake task gets executed, `config.eager_load` is overridden by [`config.rake_eager_load`][], which is `false` by default. So, by default, in production environments Rake tasks do not eager load the application.
 
 The order in which files are eager-loaded is undefined.
 
 During eager loading, Rails invokes `Zeitwerk::Loader.eager_load_all`. That ensures all gem dependencies managed by Zeitwerk are eager-loaded too.
 
+
 [`config.eager_load`]: configuring.html#config-eager-load
+[`config.rake_eager_load`]: configuring.html#config-rake-eager-load
 
 Single Table Inheritance
 ------------------------

--- a/guides/source/ja/autoloading_and_reloading_constants.md
+++ b/guides/source/ja/autoloading_and_reloading_constants.md
@@ -319,13 +319,14 @@ eager loading
 
 一般的にproduction的な環境では、アプリケーションの起動時にアプリケーションコードをすべて読み込んでおく方が望ましいと言えます。eager loading（一括読み込み）はすべてをメモリ上に読み込むことでリクエストに即座に対応できるように備え、[CoW](https://ja.wikipedia.org/wiki/%E3%82%B3%E3%83%94%E3%83%BC%E3%82%AA%E3%83%B3%E3%83%A9%E3%82%A4%E3%83%88)（コピーオンライト）との相性にも優れています。
 
-eager loadingは[`config.eager_load`][]フラグで制御します。これは`production`モードではデフォルトで有効です。
+eager loadingは[`config.eager_load`][]フラグで制御します。これは`production`以外のすべての環境でデフォルトで無効になっています。rakeタスクが実行されると、`config.eager_load`は[`config.rake_eager_load`][]で上書きされ、デフォルトでは`false`になります。つまり、production環境で実行するrakeタスクは、デフォルトではアプリケーションをeager loadingしません。
 
 ファイルがeager loadingされる順序は未定義です。
 
 eager loading中に、Railsは`Zeitwerk::Loader.eager_load_all`を呼び出します。これはすべてのZeitwerkが管理している依存gemもeager loadされていることを保証します。
 
 [`config.eager_load`]: configuring.html#config-eager-load
+[`config.rake_eager_load`]: configuring.html#config-rake-eager-load
 
 STI（単一テーブル継承）
 ------------------------


### PR DESCRIPTION
本家7-0-stableブランチの以下の更新を訳文に反映しました。
https://github.com/rails/rails/commit/6738245527175921066551f75c8c8e3af6213c7a 

量が少ないので、CIパス後にマージします。