### PR TITLE
各ガイドに edgeguides へのリンクを追加

### DIFF
--- a/guides/rails_guides/markdown_ja.rb
+++ b/guides/rails_guides/markdown_ja.rb
@@ -97,8 +97,16 @@ module RailsGuides
         File.join('https://github.com/yasslab/railsguides.jp/tree/master/guides/source/ja', @markdown_file_name)
       end
 
+      def edgeguides_content_link
+        File.join(
+             'https://edgeguides.rubyonrails.org/',
+             @markdown_file_name.sub('.md', '.html')
+             )
+      end
+
       def render_page
         @view.content_for(:markdown_path_on_github) { markdown_path_on_github }
+        @view.content_for(:edgeguides_content_link) { edgeguides_content_link }
         @view.content_for(:references) { @references }
         super
       end

--- a/guides/source/ja/layout.html.erb
+++ b/guides/source/ja/layout.html.erb
@@ -152,9 +152,13 @@
           <%= yield.html_safe %>
           <%= yield :references %>
 
-          <% if yield(:markdown_path_on_github).present? %>
+          <% if yield(:markdown_path_on_github).present? ||
+	        yield(:edgeguides_content_link).present? %>
             <p id="mdEditLink" style="font-size: 1.1428em; text-align: right;">
-              <%= link_to '🖋 GitHubで編集を提案する', yield(:markdown_path_on_github) %>
+              <%= link_to '🖋 GitHubで編集を提案する', yield(:markdown_path_on_github) if yield(:markdown_path_on_github).present? %>
+	      <%= ' / ' if yield(:markdown_path_on_github).present? &&
+	                   yield(:edgeguides_content_link).present? %>
+              <%= link_to '📕 英語で読む', yield(:edgeguides_content_link) if yield(:edgeguides_content_link).present? %>
             </p>
           <% end %>
 


### PR DESCRIPTION
Close #1452

以下に対応する PR です。

> 各ページからそれぞれの元ページへの直接の参照を追加しておいていただきたいです。

https://github.com/yasslab/railsguides.jp/assets/155807/3c17e580-ac5e-42db-83e4-c3caf1cf71da

