### PR TITLE
active_support_instrumentation.mdを更新（7-0-stable）

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -3,9 +3,9 @@
 Active Support Instrumentation
 ==============================
 
-Active Support is a part of core Rails that provides Ruby language extensions, utilities, and other things. One of the things it includes is an instrumentation API that can be used inside an application to measure certain actions that occur within Ruby code, such as that inside a Rails application or the framework itself. It is not limited to Rails, however. It can be used independently in other Ruby scripts if it is so desired.
+Active Support is a part of core Rails that provides Ruby language extensions, utilities, and other things. One of the things it includes is an instrumentation API that can be used inside an application to measure certain actions that occur within Ruby code, such as those inside a Rails application or the framework itself. It is not limited to Rails, however. It can be used independently in other Ruby scripts if desired.
 
-In this guide, you will learn how to use the instrumentation API inside of Active Support to measure events inside of Rails and other Ruby code.
+In this guide, you will learn how to use the Active Support's instrumentation API to measure events inside of Rails and other Ruby code.
 
 After reading this guide, you will know:
 
@@ -19,25 +19,25 @@ After reading this guide, you will know:
 Introduction to Instrumentation
 -------------------------------
 
-The instrumentation API provided by Active Support allows developers to provide hooks which other developers may hook into. There are several of these within the [Rails framework](#rails-framework-hooks). With this API, developers can choose to be notified when certain events occur inside their application or another piece of Ruby code.
+The instrumentation API provided by Active Support allows developers to provide hooks which other developers may hook into. There are [several of these](#rails-framework-hooks) within the Rails framework. With this API, developers can choose to be notified when certain events occur inside their application or another piece of Ruby code.
 
-For example, there is a hook provided within Active Record that is called every time Active Record uses an SQL query on a database. This hook could be **subscribed** to, and used to track the number of queries during a certain action. There's another hook around the processing of an action of a controller. This could be used, for instance, to track how long a specific action has taken.
+For example, there is [a hook](#sql-active-record) provided within Active Record that is called every time Active Record uses an SQL query on a database. This hook could be **subscribed** to, and used to track the number of queries during a certain action. There's [another hook](#process-action-action-controller) around the processing of an action of a controller. This could be used, for instance, to track how long a specific action has taken.
 
 You are even able to [create your own events](#creating-custom-events) inside your application which you can later subscribe to.
 
 Subscribing to an Event
 -----------------------
 
-Subscribing to an event is easy. Use `ActiveSupport::Notifications.subscribe` with a block to
+Subscribing to an event is easy. Use [`ActiveSupport::Notifications.subscribe`][] with a block to
 listen to any notification.
 
 The block receives the following arguments:
 
-* The name of the event
+* Name of the event
 * Time when it started
 * Time when it finished
 * A unique ID for the instrumenter that fired the event
-* The payload (described in future sections)
+* The payload for the event
 
 ```ruby
 ActiveSupport::Notifications.subscribe "process_action.action_controller" do |name, started, finished, unique_id, data|
@@ -46,7 +46,7 @@ ActiveSupport::Notifications.subscribe "process_action.action_controller" do |na
 end
 ```
 
-If you are concerned about the accuracy of `started` and `finished` to compute a precise elapsed time then use `ActiveSupport::Notifications.monotonic_subscribe`. The given block would receive the same arguments as above but the `started` and `finished` will have values with an accurate monotonic time instead of wall-clock time.
+If you are concerned about the accuracy of `started` and `finished` to compute a precise elapsed time, then use [`ActiveSupport::Notifications.monotonic_subscribe`][]. The given block would receive the same arguments as above, but the `started` and `finished` will have values with an accurate monotonic time instead of wall-clock time.
 
 ```ruby
 ActiveSupport::Notifications.monotonic_subscribe "process_action.action_controller" do |name, started, finished, unique_id, data|
@@ -55,7 +55,7 @@ ActiveSupport::Notifications.monotonic_subscribe "process_action.action_controll
 end
 ```
 
-Defining all those block arguments each time can be tedious. You can easily create an `ActiveSupport::Notifications::Event`
+Defining all those block arguments each time can be tedious. You can easily create an [`ActiveSupport::Notifications::Event`][]
 from block arguments like this:
 
 ```ruby
@@ -82,17 +82,8 @@ ActiveSupport::Notifications.subscribe "process_action.action_controller" do |ev
 end
 ```
 
-Most times you only care about the data itself. Here is a shortcut to just get the data.
-
-```ruby
-ActiveSupport::Notifications.subscribe "process_action.action_controller" do |*args|
-  data = args.extract_options!
-  data # { extra: :information }
-end
-```
-
 You may also subscribe to events matching a regular expression. This enables you to subscribe to
-multiple events at once. Here's how to subscribe to everything from `ActionController`.
+multiple events at once. Here's how to subscribe to everything from `ActionController`:
 
 ```ruby
 ActiveSupport::Notifications.subscribe /action_controller/ do |*args|
@@ -100,63 +91,18 @@ ActiveSupport::Notifications.subscribe /action_controller/ do |*args|
 end
 ```
 
+[`ActiveSupport::Notifications::Event`]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications/Event.html
+[`ActiveSupport::Notifications.monotonic_subscribe`]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html#method-c-monotonic_subscribe
+[`ActiveSupport::Notifications.subscribe`]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html#method-c-subscribe
 
-Rails framework hooks
+Rails Framework Hooks
 ---------------------
 
-Within the Ruby on Rails framework, there are a number of hooks provided for common events. These are detailed below.
+Within the Ruby on Rails framework, there are a number of hooks provided for common events. These events and their payloads are detailed below.
 
 ### Action Controller
 
-#### write_fragment.action_controller
-
-| Key    | Value            |
-| ------ | ---------------- |
-| `:key` | The complete key |
-
-```ruby
-{
-  key: 'posts/1-dashboard-view'
-}
-```
-
-#### read_fragment.action_controller
-
-| Key    | Value            |
-| ------ | ---------------- |
-| `:key` | The complete key |
-
-```ruby
-{
-  key: 'posts/1-dashboard-view'
-}
-```
-
-#### expire_fragment.action_controller
-
-| Key    | Value            |
-| ------ | ---------------- |
-| `:key` | The complete key |
-
-```ruby
-{
-  key: 'posts/1-dashboard-view'
-}
-```
-
-#### exist_fragment?.action_controller
-
-| Key    | Value            |
-| ------ | ---------------- |
-| `:key` | The complete key |
-
-```ruby
-{
-  key: 'posts/1-dashboard-view'
-}
-```
-
-#### start_processing.action_controller
+#### `start_processing.action_controller`
 
 | Key           | Value                                                     |
 | ------------- | --------------------------------------------------------- |
@@ -180,7 +126,7 @@ Within the Ruby on Rails framework, there are a number of hooks provided for com
 }
 ```
 
-#### process_action.action_controller
+#### `process_action.action_controller`
 
 | Key             | Value                                                     |
 | --------------- | --------------------------------------------------------- |
@@ -191,8 +137,8 @@ Within the Ruby on Rails framework, there are a number of hooks provided for com
 | `:format`       | html/js/json/xml etc                                      |
 | `:method`       | HTTP request verb                                         |
 | `:path`         | Request path                                              |
-| `:request`      | The `ActionDispatch::Request`                             |
-| `:response`     | The `ActionDispatch::Response`                            |
+| `:request`      | The [`ActionDispatch::Request`][] object                  |
+| `:response`     | The [`ActionDispatch::Response`][] object                 |
 | `:status`       | HTTP status code                                          |
 | `:view_runtime` | Amount spent in view in ms                                |
 | `:db_runtime`   | Amount spent executing database queries in ms             |
@@ -214,25 +160,25 @@ Within the Ruby on Rails framework, there are a number of hooks provided for com
 }
 ```
 
-#### send_file.action_controller
+#### `send_file.action_controller`
 
 | Key     | Value                     |
 | ------- | ------------------------- |
 | `:path` | Complete path to the file |
 
-INFO. Additional keys may be added by the caller.
+Additional keys may be added by the caller.
 
-#### send_data.action_controller
+#### `send_data.action_controller`
 
 `ActionController` does not add any specific information to the payload. All options are passed through to the payload.
 
-#### redirect_to.action_controller
+#### `redirect_to.action_controller`
 
-| Key         | Value                         |
-| ----------- | ----------------------------- |
-| `:status`   | HTTP response code            |
-| `:location` | URL to redirect to            |
-| `:request`  | The `ActionDispatch::Request` |
+| Key         | Value                                    |
+| ----------- | ---------------------------------------- |
+| `:status`   | HTTP response code                       |
+| `:location` | URL to redirect to                       |
+| `:request`  | The [`ActionDispatch::Request`][] object |
 
 ```ruby
 {
@@ -242,7 +188,7 @@ INFO. Additional keys may be added by the caller.
 }
 ```
 
-#### halted_callback.action_controller
+#### `halted_callback.action_controller`
 
 | Key       | Value                         |
 | --------- | ----------------------------- |
@@ -254,16 +200,66 @@ INFO. Additional keys may be added by the caller.
 }
 ```
 
-#### unpermitted_parameters.action_controller
+#### `unpermitted_parameters.action_controller`
 
 | Key           | Value                                                                         |
 | ------------- | ----------------------------------------------------------------------------- |
 | `:keys`       | The unpermitted keys                                                          |
 | `:context`    | Hash with the following keys: `:controller`, `:action`, `:params`, `:request` |
 
+### Action Controller — Caching
+
+#### `write_fragment.action_controller`
+
+| Key    | Value            |
+| ------ | ---------------- |
+| `:key` | The complete key |
+
+```ruby
+{
+  key: 'posts/1-dashboard-view'
+}
+```
+
+#### `read_fragment.action_controller`
+
+| Key    | Value            |
+| ------ | ---------------- |
+| `:key` | The complete key |
+
+```ruby
+{
+  key: 'posts/1-dashboard-view'
+}
+```
+
+#### `expire_fragment.action_controller`
+
+| Key    | Value            |
+| ------ | ---------------- |
+| `:key` | The complete key |
+
+```ruby
+{
+  key: 'posts/1-dashboard-view'
+}
+```
+
+#### `exist_fragment?.action_controller`
+
+| Key    | Value            |
+| ------ | ---------------- |
+| `:key` | The complete key |
+
+```ruby
+{
+  key: 'posts/1-dashboard-view'
+}
+```
+
 ### Action Dispatch
 
-#### process_middleware.action_dispatch
+#### `process_middleware.action_dispatch`
 
 | Key           | Value                  |
 | ------------- | ---------------------- |
@@ -271,7 +267,7 @@ INFO. Additional keys may be added by the caller.
 
 ### Action View
 
-#### render_template.action_view
+#### `render_template.action_view`
 
 | Key           | Value                 |
 | ------------- | --------------------- |
@@ -285,7 +281,7 @@ INFO. Additional keys may be added by the caller.
 }
 ```
 
-#### render_partial.action_view
+#### `render_partial.action_view`
 
 | Key           | Value                 |
 | ------------- | --------------------- |
@@ -297,7 +293,7 @@ INFO. Additional keys may be added by the caller.
 }
 ```
 
-#### render_collection.action_view
+#### `render_collection.action_view`
 
 | Key           | Value                                 |
 | ------------- | ------------------------------------- |
@@ -305,7 +301,7 @@ INFO. Additional keys may be added by the caller.
 | `:count`      | Size of collection                    |
 | `:cache_hits` | Number of partials fetched from cache |
 
-`:cache_hits` is only included if the collection is rendered with `cached: true`.
+The `:cache_hits` key is only included if the collection is rendered with `cached: true`.
 
 ```ruby
 {
@@ -315,7 +311,7 @@ INFO. Additional keys may be added by the caller.
 }
 ```
 
-#### render_layout.action_view
+#### `render_layout.action_view`
 
 | Key           | Value                 |
 | ------------- | --------------------- |
@@ -328,9 +324,12 @@ INFO. Additional keys may be added by the caller.
 }
 ```
 
+[`ActionDispatch::Request`]: https://api.rubyonrails.org/classes/ActionDispatch/Request.html
+[`ActionDispatch::Response`]: https://api.rubyonrails.org/classes/ActionDispatch/Response.html
+
 ### Active Record
 
-#### sql.active_record
+#### `sql.active_record`
 
 | Key                  | Value                                    |
 | -------------------- | ---------------------------------------- |
@@ -342,7 +341,7 @@ INFO. Additional keys may be added by the caller.
 | `:statement_name`    | SQL Statement name                       |
 | `:cached`            | `true` is added when cached queries used |
 
-INFO. The adapters will add their own data as well.
+Adapters may add their own data as well.
 
 ```ruby
 {
@@ -355,7 +354,7 @@ INFO. The adapters will add their own data as well.
 }
 ```
 
-#### instantiation.active_record
+#### `instantiation.active_record`
 
 | Key              | Value                                     |
 | ---------------- | ----------------------------------------- |
@@ -371,7 +370,7 @@ INFO. The adapters will add their own data as well.
 
 ### Action Mailer
 
-#### deliver.action_mailer
+#### `deliver.action_mailer`
 
 | Key                   | Value                                                |
 | --------------------- | ---------------------------------------------------- |
@@ -399,7 +398,7 @@ INFO. The adapters will add their own data as well.
 }
 ```
 
-#### process.action_mailer
+#### `process.action_mailer`
 
 | Key           | Value                    |
 | ------------- | ------------------------ |
@@ -415,27 +414,36 @@ INFO. The adapters will add their own data as well.
 }
 ```
 
-### Active Support
+### Active Support — Caching
 
-#### cache_read.active_support
+#### `cache_read.active_support`
 
-| Key                | Value                                               |
-| ------------------ | --------------------------------------------------- |
-| `:key`             | Key used in the store                               |
-| `:store`           | Name of the store class                             |
-| `:hit`             | If this read is a hit                               |
-| `:super_operation` | `:fetch` is added when a read is used with `#fetch` |
+| Key                | Value                   |
+| ------------------ | ----------------------- |
+| `:key`             | Key used in the store   |
+| `:store`           | Name of the store class |
+| `:hit`             | If this read is a hit   |
+| `:super_operation` | `:fetch` if a read is done with [`fetch`][ActiveSupport::Cache::Store#fetch] |
 
-#### cache_generate.active_support
+#### `cache_read_multi.active_support`
 
-This event is only used when `#fetch` is called with a block.
+| Key                | Value                   |
+| ------------------ | ----------------------- |
+| `:key`             | Keys used in the store  |
+| `:store`           | Name of the store class |
+| `:hits`            | Keys of cache hits      |
+| `:super_operation` | `:fetch_multi` if a read is done with [`fetch_multi`][ActiveSupport::Cache::Store#fetch_multi] |
+
+#### `cache_generate.active_support`
+
+This event is only emitted when [`fetch`][ActiveSupport::Cache::Store#fetch] is called with a block.
 
 | Key      | Value                   |
 | -------- | ----------------------- |
 | `:key`   | Key used in the store   |
 | `:store` | Name of the store class |
 
-INFO. Options passed to fetch will be merged with the payload when writing to the store
+Options passed to `fetch` will be merged with the payload when writing to the store.
 
 ```ruby
 {
@@ -444,16 +452,16 @@ INFO. Options passed to fetch will be merged with the payload when writing to th
 }
 ```
 
-#### cache_fetch_hit.active_support
+#### `cache_fetch_hit.active_support`
 
-This event is only used when `#fetch` is called with a block.
+This event is only emitted when [`fetch`][ActiveSupport::Cache::Store#fetch] is called with a block.
 
 | Key      | Value                   |
 | -------- | ----------------------- |
 | `:key`   | Key used in the store   |
 | `:store` | Name of the store class |
 
-INFO. Options passed to fetch will be merged with the payload.
+Options passed to `fetch` will be merged with the payload.
 
 ```ruby
 {
@@ -462,14 +470,14 @@ INFO. Options passed to fetch will be merged with the payload.
 }
 ```
 
-#### cache_write.active_support
+#### `cache_write.active_support`
 
 | Key      | Value                   |
 | -------- | ----------------------- |
 | `:key`   | Key used in the store   |
 | `:store` | Name of the store class |
 
-INFO. Cache stores may add their own keys
+Cache stores may add their own data as well.
 
 ```ruby
 {
@@ -478,7 +486,52 @@ INFO. Cache stores may add their own keys
 }
 ```
 
-#### cache_delete.active_support
+#### `cache_write_multi.active_support`
+
+| Key      | Value                                |
+| -------- | ------------------------------------ |
+| `:key`   | Keys and values written to the store |
+| `:store` | Name of the store class              |
+
+
+#### `cache_increment.active_support`
+
+This event is only emitted when using [`MemCacheStore`][ActiveSupport::Cache::MemCacheStore]
+or [`RedisCacheStore`][ActiveSupport::Cache::RedisCacheStore].
+
+| Key       | Value                   |
+| --------- | ----------------------- |
+| `:key`    | Key used in the store   |
+| `:store`  | Name of the store class |
+| `:amount` | Increment amount        |
+
+```ruby
+{
+  key: "bottles-of-beer",
+  store: "ActiveSupport::Cache::RedisCacheStore",
+  amount: 99
+}
+```
+
+#### `cache_decrement.active_support`
+
+This event is only emitted when using the Memcached or Redis cache stores.
+
+| Key       | Value                   |
+| --------- | ----------------------- |
+| `:key`    | Key used in the store   |
+| `:store`  | Name of the store class |
+| `:amount` | Decrement amount        |
+
+```ruby
+{
+  key: "bottles-of-beer",
+  store: "ActiveSupport::Cache::RedisCacheStore",
+  amount: 1
+}
+```
+
+#### `cache_delete.active_support`
 
 | Key      | Value                   |
 | -------- | ----------------------- |
@@ -492,7 +545,65 @@ INFO. Cache stores may add their own keys
 }
 ```
 
-#### cache_exist?.active_support
+#### `cache_delete_multi.active_support`
+
+| Key      | Value                   |
+| -------- | ----------------------- |
+| `:key`   | Keys used in the store  |
+| `:store` | Name of the store class |
+
+#### `cache_delete_matched.active_support`
+
+This event is only emitted when using [`RedisCacheStore`][ActiveSupport::Cache::RedisCacheStore],
+[`FileStore`][ActiveSupport::Cache::FileStore], or [`MemoryStore`][ActiveSupport::Cache::MemoryStore].
+
+| Key      | Value                   |
+| -------- | ----------------------- |
+| `:key`   | Key pattern used        |
+| `:store` | Name of the store class |
+
+```ruby
+{
+  key: "posts/*",
+  store: "ActiveSupport::Cache::RedisCacheStore"
+}
+```
+
+#### `cache_cleanup.active_support`
+
+This event is only emitted when using [`MemoryStore`][ActiveSupport::Cache::MemoryStore].
+
+| Key      | Value                                         |
+| -------- | --------------------------------------------- |
+| `:store` | Name of the store class                       |
+| `:size`  | Number of entries in the cache before cleanup |
+
+```ruby
+{
+  store: "ActiveSupport::Cache::MemoryStore",
+  size: 9001
+}
+```
+
+#### `cache_prune.active_support`
+
+This event is only emitted when using [`MemoryStore`][ActiveSupport::Cache::MemoryStore].
+
+| Key      | Value                                         |
+| -------- | --------------------------------------------- |
+| `:store` | Name of the store class                       |
+| `:key`   | Target size (in bytes) for the cache          |
+| `:from`  | Size (in bytes) of the cache before prune     |
+
+```ruby
+{
+  store: "ActiveSupport::Cache::MemoryStore",
+  key: 5000,
+  from: 9001
+}
+```
+
+#### `cache_exist?.active_support`
 
 | Key      | Value                   |
 | -------- | ----------------------- |
@@ -505,24 +616,31 @@ INFO. Cache stores may add their own keys
   store: "ActiveSupport::Cache::MemCacheStore"
 }
 ```
+
+[ActiveSupport::Cache::FileStore]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/FileStore.html
+[ActiveSupport::Cache::MemCacheStore]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/MemCacheStore.html
+[ActiveSupport::Cache::MemoryStore]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/MemoryStore.html
+[ActiveSupport::Cache::RedisCacheStore]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html
+[ActiveSupport::Cache::Store#fetch]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch
+[ActiveSupport::Cache::Store#fetch_multi]: https://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html#method-i-fetch_multi
 
 ### Active Job
 
-#### enqueue_at.active_job
+#### `enqueue_at.active_job`
 
 | Key          | Value                                  |
 | ------------ | -------------------------------------- |
 | `:adapter`   | QueueAdapter object processing the job |
 | `:job`       | Job object                             |
 
-#### enqueue.active_job
+#### `enqueue.active_job`
 
 | Key          | Value                                  |
 | ------------ | -------------------------------------- |
 | `:adapter`   | QueueAdapter object processing the job |
 | `:job`       | Job object                             |
 
-#### enqueue_retry.active_job
+#### `enqueue_retry.active_job`
 
 | Key          | Value                                  |
 | ------------ | -------------------------------------- |
@@ -531,21 +649,21 @@ INFO. Cache stores may add their own keys
 | `:error`     | The error that caused the retry        |
 | `:wait`      | The delay of the retry                 |
 
-#### perform_start.active_job
+#### `perform_start.active_job`
 
 | Key          | Value                                  |
 | ------------ | -------------------------------------- |
 | `:adapter`   | QueueAdapter object processing the job |
 | `:job`       | Job object                             |
 
-#### perform.active_job
+#### `perform.active_job`
 
 | Key          | Value                                  |
 | ------------ | -------------------------------------- |
 | `:adapter`   | QueueAdapter object processing the job |
 | `:job`       | Job object                             |
 
-#### retry_stopped.active_job
+#### `retry_stopped.active_job`
 
 | Key          | Value                                  |
 | ------------ | -------------------------------------- |
@@ -553,7 +671,7 @@ INFO. Cache stores may add their own keys
 | `:job`       | Job object                             |
 | `:error`     | The error that caused the retry        |
 
-#### discard.active_job
+#### `discard.active_job`
 
 | Key          | Value                                  |
 | ------------ | -------------------------------------- |
@@ -563,7 +681,7 @@ INFO. Cache stores may add their own keys
 
 ### Action Cable
 
-#### perform_action.action_cable
+#### `perform_action.action_cable`
 
 | Key              | Value                     |
 | ---------------- | ------------------------- |
@@ -571,7 +689,7 @@ INFO. Cache stores may add their own keys
 | `:action`        | The action                |
 | `:data`          | A hash of data            |
 
-#### transmit.action_cable
+#### `transmit.action_cable`
 
 | Key              | Value                     |
 | ---------------- | ------------------------- |
@@ -579,19 +697,19 @@ INFO. Cache stores may add their own keys
 | `:data`          | A hash of data            |
 | `:via`           | Via                       |
 
-#### transmit_subscription_confirmation.action_cable
+#### `transmit_subscription_confirmation.action_cable`
 
 | Key              | Value                     |
 | ---------------- | ------------------------- |
 | `:channel_class` | Name of the channel class |
 
-#### transmit_subscription_rejection.action_cable
+#### `transmit_subscription_rejection.action_cable`
 
 | Key              | Value                     |
 | ---------------- | ------------------------- |
 | `:channel_class` | Name of the channel class |
 
-#### broadcast.action_cable
+#### `broadcast.action_cable`
 
 | Key             | Value                |
 | --------------- | -------------------- |
@@ -601,7 +719,23 @@ INFO. Cache stores may add their own keys
 
 ### Active Storage
 
-#### service_upload.active_storage
+#### `preview.active_storage`
+
+| Key          | Value               |
+| ------------ | ------------------- |
+| `:key`       | Secure token        |
+
+#### `transform.active_storage`
+
+#### `analyze.active_storage`
+
+| Key          | Value                          |
+| ------------ | ------------------------------ |
+| `:analyzer`  | Name of analyzer e.g., ffprobe |
+
+### Active Storage — Storage Service
+
+#### `service_upload.active_storage`
 
 | Key          | Value                        |
 | ------------ | ---------------------------- |
@@ -609,14 +743,14 @@ INFO. Cache stores may add their own keys
 | `:service`   | Name of the service          |
 | `:checksum`  | Checksum to ensure integrity |
 
-#### service_streaming_download.active_storage
+#### `service_streaming_download.active_storage`
 
 | Key          | Value               |
 | ------------ | ------------------- |
 | `:key`       | Secure token        |
 | `:service`   | Name of the service |
 
-#### service_download_chunk.active_storage
+#### `service_download_chunk.active_storage`
 
 | Key          | Value                           |
 | ------------ | ------------------------------- |
@@ -624,28 +758,28 @@ INFO. Cache stores may add their own keys
 | `:service`   | Name of the service             |
 | `:range`     | Byte range attempted to be read |
 
-#### service_download.active_storage
+#### `service_download.active_storage`
 
 | Key          | Value               |
 | ------------ | ------------------- |
 | `:key`       | Secure token        |
 | `:service`   | Name of the service |
 
-#### service_delete.active_storage
+#### `service_delete.active_storage`
 
 | Key          | Value               |
 | ------------ | ------------------- |
 | `:key`       | Secure token        |
 | `:service`   | Name of the service |
 
-#### service_delete_prefixed.active_storage
+#### `service_delete_prefixed.active_storage`
 
 | Key          | Value               |
 | ------------ | ------------------- |
 | `:prefix`    | Key prefix          |
 | `:service`   | Name of the service |
 
-#### service_exist.active_storage
+#### `service_exist.active_storage`
 
 | Key          | Value                       |
 | ------------ | --------------------------- |
@@ -653,7 +787,7 @@ INFO. Cache stores may add their own keys
 | `:service`   | Name of the service         |
 | `:exist`     | File or blob exists or not  |
 
-#### service_url.active_storage
+#### `service_url.active_storage`
 
 | Key          | Value               |
 | ------------ | ------------------- |
@@ -661,42 +795,28 @@ INFO. Cache stores may add their own keys
 | `:service`   | Name of the service |
 | `:url`       | Generated URL       |
 
-#### service_update_metadata.active_storage
+#### `service_update_metadata.active_storage`
 
-| Key             | Value                          |
-| --------------- | ------------------------------ |
-| `:key`          | Secure token                   |
-| `:service`      | Name of the service            |
-| `:content_type` | HTTP Content-Type field        |
-| `:disposition`  | HTTP Content-Disposition field |
+This event is only emitted when using the Google Cloud Storage service.
 
-INFO. The only ActiveStorage service that provides this hook so far is GCS.
-
-#### preview.active_storage
-
-| Key          | Value               |
-| ------------ | ------------------- |
-| `:key`       | Secure token        |
-
-#### transform.active_storage
-
-#### analyze.active_storage
-
-| Key          | Value                          |
-| ------------ | ------------------------------ |
-| `:analyzer`  | Name of analyzer e.g., ffprobe |
+| Key             | Value                            |
+| --------------- | -------------------------------- |
+| `:key`          | Secure token                     |
+| `:service`      | Name of the service              |
+| `:content_type` | HTTP `Content-Type` field        |
+| `:disposition`  | HTTP `Content-Disposition` field |
 
 ### Railties
 
-#### load_config_initializer.railties
+#### `load_config_initializer.railties`
 
-| Key            | Value                                                 |
-| -------------- | ----------------------------------------------------- |
-| `:initializer` | Path to loaded initializer from `config/initializers` |
+| Key            | Value                                               |
+| -------------- | --------------------------------------------------- |
+| `:initializer` | Path of loaded initializer in `config/initializers` |
 
 ### Rails
 
-#### deprecation.rails
+#### `deprecation.rails`
 
 | Key          | Value                           |
 | ------------ | ------------------------------- |
@@ -717,9 +837,9 @@ information about it.
 Creating Custom Events
 ----------------------
 
-Adding your own events is easy as well. `ActiveSupport::Notifications` will take care of
-all the heavy lifting for you. Simply call `instrument` with a `name`, `payload` and a block.
-The notification will be sent after the block returns. `ActiveSupport` will generate the start and end times
+Adding your own events is easy as well. Active Support will take care of
+all the heavy lifting for you. Simply call [`ActiveSupport::Notifications.instrument`][] with a `name`, `payload`, and a block.
+The notification will be sent after the block returns. Active Support will generate the start and end times,
 and add the instrumenter's unique ID. All data passed into the `instrument` call will make
 it into the payload.
 
@@ -739,7 +859,7 @@ ActiveSupport::Notifications.subscribe "my.custom.event" do |name, started, fini
 end
 ```
 
-You also have the option to call instrument without passing a block. This lets you leverage the
+You may also call `instrument` without passing a block. This lets you leverage the
 instrumentation infrastructure for other messaging uses.
 
 ```ruby
@@ -752,3 +872,5 @@ end
 
 You should follow Rails conventions when defining your own events. The format is: `event.library`.
 If your application is sending Tweets, you should create an event named `tweet.twitter`.
+
+[`ActiveSupport::Notifications.instrument`]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html#method-c-instrument


### PR DESCRIPTION
7-0-stableブランチの https://github.com/rails/rails/pull/48309/commits/4e0079f09ad96bf899cd7e0fb10f1c32d21e87fb （https://github.com/rails/rails/pull/48309 ）までの原文active_support_instrumentation.md更新に沿って訳文を更新しました。

