### PR TITLE
to_sのdeprecationに関する訳の修正

### DIFF
--- a/guides/source/ja/7_0_release_notes.md
+++ b/guides/source/ja/7_0_release_notes.md
@@ -299,7 +299,7 @@ Active Support
 
     この非推奨化は、Ruby 3.1である種のオブジェクトの式展開を高速化する[最適化](https://github.com/ruby/ruby/commit/b08dacfea39ad8da3f1fd7fdd0e4538cc892ec44)を利用できるようにするためのものです。
 
-    新しいアプリケーションではそれらのクラスの`#to_s`メソッドがオーバーライドされます。既存のアプリケーションでは`config.active_support.disable_to_s_conversion`で無効にできます。
+    新しいアプリケーションではそれらのクラスの`#to_s`メソッドがオーバーライドされません。既存のアプリケーションでは`config.active_support.disable_to_s_conversion`でオーバーライドされないようにできます。
 
 ### 主な変更点
 


### PR DESCRIPTION
原文では will **not** となっているので「オーバーライドされない」が正しいかと思います。
```
New applications will not have the `#to_s` method overridden on those classes, existing applications can use
```
原文:  https://github.com/rails/rails/blob/593893c901f87b4ed205751f72df41519b4d2da3/guides/source/7_0_release_notes.md?plain=1#L288

Configuring Rails Applicationsページの翻訳は合っていそうです。
https://github.com/yasslab/railsguides.jp/blob/e53fbf22bfa0ee7333ffb2cb5ac1ce43cd34c74f/guides/source/ja/configuring.md?plain=1#L1808-L1819
原文:  https://github.com/rails/rails/blob/593893c901f87b4ed205751f72df41519b4d2da3/guides/source/configuring.md?plain=1#L1888-L1900