### PR TITLE
v7.0でRails技術者認定試験の URL を変更した

### DIFF
--- a/guides/source/ja/index.html.erb
+++ b/guides/source/ja/index.html.erb
@@ -87,7 +87,7 @@ Ruby on Rails ガイド：体系的に Rails を学ぼう
     <a href="https://yasslab.jp/" target="_blank" rel="noopener">YassLab 株式会社</a>
   </li>
   <li>後援:
-    <a href="https://railscp.com/aboutus/" target="_blank" rel="noopener">Rails技術者認定試験</a>
+    <a href="https://railsce.com/aboutus/" target="_blank" rel="noopener">Rails技術者認定試験</a>
   </li>
   <li>誤訳などを指摘して頂いた皆さん:
     <ul>

--- a/guides/source/ja/options.html.erb
+++ b/guides/source/ja/options.html.erb
@@ -129,7 +129,7 @@ yes
 
 <!--
 <h4>Rails技術者認定シルバー試験を検討されている方へ</h4>
-Railsガイドは<a href="https://railsce.com/">Rails技術者認定シルバー試験</a>の推奨教材として認定されています。
+Railsガイドは<a href="https://railsce.com/silver">Rails技術者認定シルバー試験</a>の推奨教材として認定されています。
 シルバー試験の受験を検討されている方は、ぜひ試験の参考書としてお役立てください。
 <br />
 <br />

--- a/guides/source/ja/options.html.erb
+++ b/guides/source/ja/options.html.erb
@@ -45,7 +45,7 @@ yes
   <li>Ruby on RailsでWebサービス開発を学んでいる学習者</li>
   <li>Ruby on RailsでWebサービス開発に関わっているエンジニア</li> 
   <li>Ruby on Railsの仕組みを詳しく知りたい人、オフラインで学びたい人</li>
-  <li><a href="https://www.railscp.com/">Rails技術者認定試験</a>の受験を考えている人</li>
+  <li><a href="https://railsce.com/">Rails技術者認定試験</a>の受験を考えている人</li>
 </ul>
 
 
@@ -129,11 +129,11 @@ yes
 
 <!--
 <h4>Rails技術者認定シルバー試験を検討されている方へ</h4>
-Railsガイドは<a href="https://www.railscp.com/">Rails技術者認定シルバー試験</a>の推奨教材として認定されています。
+Railsガイドは<a href="https://railsce.com/">Rails技術者認定シルバー試験</a>の推奨教材として認定されています。
 シルバー試験の受験を検討されている方は、ぜひ試験の参考書としてお役立てください。
 <br />
 <br />
-<a href="https://www.railscp.com/">
+<a href="https://railsce.com/">
   <img src="/images/logos/railscp.png"
        alt="Rails技術者認定試験" width="320px" /></a>
   -->


### PR DESCRIPTION
cf. #1925

### やったこと
v7.0でRails技術者認定試験の URL を変更しました

```diff
- [www.]railscp.com 
+ railsce.com 
```

### 後でやること

- 本番環境のLPにも反映されているか確認し、反映されていなければ別途対応する
- 過去バージョンの対応