### PR TITLE
v6.1でRails技術者認定試験の URL を変更した

### DIFF
--- a/guides/source/ja/index.html.erb
+++ b/guides/source/ja/index.html.erb
@@ -86,7 +86,7 @@ Ruby on Rails ガイド：体系的に Rails を学ぼう
     <a href="https://yasslab.jp/" target="_blank" rel="noopener">YassLab 株式会社</a>
   </li>
   <li>後援:
-    <a href="https://railscp.com/aboutus/" target="_blank" rel="noopener">Rails技術者認定試験</a>
+    <a href="https://railsce.com/aboutus/" target="_blank" rel="noopener">Rails技術者認定試験</a>
   </li>
   <li>誤訳などを指摘して頂いた皆さん:
     <ul>

--- a/guides/source/ja/index.html.erb
+++ b/guides/source/ja/index.html.erb
@@ -16,7 +16,7 @@ Ruby on Rails ガイド：体系的に Rails を学ぼう
     <dt>Railsの仕組みを体系的に学べる大型コンテンツ</dt>
     <dd><a href="http://guides.rubyonrails.org/" target="_blank" rel="noopener">Rails Guides</a> に基づいた1,600ページ超えの大型リファレンスです。</dd>
     <dt>プロダクト開発に役立つ実践的な知識が満載</dt>
-    <dd><a href="https://railstutorial.jp/" target="_blank" rel="noopener">Railsチュートリアル</a>を完走し、Webサービス開発中の方に最適です。</dd>
+    <dd><a href="https://railstutorial.jp/" target="_blank" rel="noopener">Railsチュートリアル</a>を完走し、Webサービス開発中の人に最適です。</dd>
     <dt>全文検索やバージョン毎の検索にも対応</dt>
     <dd><a href="https://railsguides.jp/pro">Proプラン</a>では、さらに効率的な活用をサポートします。</dd>
    </dl>
@@ -81,7 +81,7 @@ Ruby on Rails ガイド：体系的に Rails を学ぼう
 <ul style="list-style: none;">
   <li>共同発起人 (翻訳): <a href="https://www.linkedin.com/pub/shozo-hatta/11/349/930">八田 昌三</a> (<a href="https://twitter.com/hachi8833">@hachi8833</a>)</li>
   <li>共同発起人 (開発): <a href="https://www.facebook.com/yasulab">安川 要平</a> (<a href="https://twitter.com/yasulab">@yasulab</a>)</li>
-  <li>コミッターの皆さん: <a href="https://twitter.com/spikeolaf">@spikeolaf</a>, <a href="https://twitter.com/dev_shia">@dev_shia</a>, <a href="https://twitter.com/netwillnet">@netwillnet</a></li>
+  <li>コミッターの皆さん: <a href="https://twitter.com/spikeolaf">@spikeolaf</a>, <a href="https://github.com/riseshia">@riseshia</a>, <a href="https://twitter.com/netwillnet">@netwillnet</a></li>
   <li>運営:
     <a href="https://yasslab.jp/" target="_blank" rel="noopener">YassLab 株式会社</a>
   </li>

--- a/guides/source/ja/options.html.erb
+++ b/guides/source/ja/options.html.erb
@@ -44,7 +44,7 @@ yes
   <li><a href="https://railstutorial.jp/">Railsチュートリアル</a>を読み終わった</li>
   <li>Railsを使って現在Webサービスを開発している方</li> 
   <li>Railsの仕組みを詳しく知りたい方、あるいは本格的に使いこなしたい方</li>
-  <li><a href="https://www.railscp.com/">Rails技術者認定シルバー試験</a>の受験を考えている方</li>
+  <li><a href="https://railsce.com/silver">Rails技術者認定シルバー試験</a>の受験を考えている方</li>
   <li><a href="https://rubyonrails.org/community/">Railsコミュニティ</a>の発展に貢献してみたい方</li>
 </ul>
 
@@ -127,11 +127,11 @@ yes
        alt="Rails技術者認定試験" width="100%" /></a></p>
 
 <h4>Rails技術者認定シルバー試験を検討されている方へ</h4>
-Railsガイドは<a href="https://www.railscp.com/">Rails技術者認定シルバー試験</a>の推奨教材として認定されています。
+Railsガイドは<a href="https://railsce.com/silver">Rails技術者認定シルバー試験</a>の推奨教材として認定されています。
 シルバー試験の受験を検討されている方は、ぜひ試験の参考書としてお役立てください。
 <br />
 <br />
-<a href="https://www.railscp.com/">
+<a href="https://railsce.com/">
   <img src="/images/logos/railscp.png"
        alt="Rails技術者認定試験" width="320px" /></a>
 


### PR DESCRIPTION
#1490 と同様の更新です。テストが通ったらマージします🛠