### PR TITLE
v6.0でRails技術者認定試験の URL を変更した

### DIFF
--- a/guides/source/ja/5_2_release_notes.md
+++ b/guides/source/ja/5_2_release_notes.md
@@ -56,7 +56,7 @@ Rails 5.2で[HTTP/2 Early Hints](https://tools.ietf.org/html/rfc8297)がサポ�
 [Pull Request](https://github.com/rails/rails/pull/31162)
 
 Rails 5.2では、アプリケーションの [Content Security Policy](https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Content-Security-Policy)（CSP）を設定する新しいDSLが使えるようになりました。グローバルなポリシーを1つ設定しておき、続いてリソースベースでポリシーをオーバーライドすることも、lambdaを使ってリクエストごとにヘッダーに値を注入することもできます（マルチテナントのアプリでアカウントのサブドメインを注入するなど）。
-詳しくは、[Rails セキュリティガイド](security.html#content-security-policy)を参照してください。
+詳しくは、[Rails セキュリティガイド](security.html#content-security-policy（csp）)を参照してください。
 
 Railties
 --------

--- a/guides/source/ja/index.html.erb
+++ b/guides/source/ja/index.html.erb
@@ -86,7 +86,7 @@ Ruby on Rails ガイド：体系的に Rails を学ぼう
     <a href="https://yasslab.jp/" target="_blank" rel="noopener">YassLab 株式会社</a>
   </li>
   <li>後援:
-    <a href="https://railscp.com/aboutus/" target="_blank" rel="noopener">Rails技術者認定試験</a>
+    <a href="https://railsce.com/aboutus/" target="_blank" rel="noopener">Rails技術者認定試験</a>
   </li>
   <li>誤訳などを指摘して頂いた皆さん:
     <ul>

--- a/guides/source/ja/options.html.erb
+++ b/guides/source/ja/options.html.erb
@@ -53,7 +53,7 @@ yes
   <li><a href="https://railstutorial.jp/">Railsチュートリアル</a>を読み終わった</li>
   <li>Railsを使って現在Webサービスを開発している方</li> 
   <li>Railsの仕組みを詳しく知りたい方、あるいは本格的に使いこなしたい方</li>
-  <li><a href="https://www.railscp.com/">Rails技術者認定シルバー試験</a>の受験を考えている方</li>
+  <li><a href="https://railsce.com/silver">Rails技術者認定シルバー試験</a>の受験を考えている方</li>
   <li><a href="https://rubyonrails.org/community/">Railsコミュニティ</a>の発展に貢献してみたい方</li>
 </ul>
 
@@ -136,11 +136,11 @@ yes
        alt="Rails技術者認定試験" width="100%" /></a></p>
 
 <h4>Rails技術者認定シルバー試験を検討されている方へ</h4>
-Railsガイドは<a href="https://www.railscp.com/">Rails技術者認定シルバー試験</a>の推奨教材として認定されています。
+Railsガイドは<a href="https://railsce.com/silver">Rails技術者認定シルバー試験</a>の推奨教材として認定されています。
 シルバー試験の受験を検討されている方は、ぜひ試験の参考書としてお役立てください。
 <br />
 <br />
-<a href="https://www.railscp.com/">
+<a href="https://www.rrailsce.com/">
   <img src="/images/logos/railscp.png"
        alt="Rails技術者認定試験" width="320px" /></a>
 


### PR DESCRIPTION
#1490 と同様の更新です。テストが通ったらマージします🛠