### PR TITLE
ActionDispatch::Response を ActionDispatch::Request へ修正する

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -1287,7 +1287,7 @@ config.action_dispatch.rescue_responses = {
 
 #### `config.action_dispatch.return_only_request_media_type_on_content_type`
 
-`ActionDispatch::Response#content_type`が`Content-Type`ヘッダーを改変せずに返すよう変更します。
+`ActionDispatch::Request#content_type`が`Content-Type`ヘッダーを改変せずに返すよう変更します。
 
 デフォルト値は、`config.load_defaults`のターゲットバージョンによって異なります。
 


### PR DESCRIPTION
なぜなら、 `config.action_dispatch.return_only_request_media_type_on_content_type` は `ActionDispatch::Request#content_type` に適用される設定だから。

- 原著 (英語版)
  - https://github.com/rails/rails/blob/v7.0.7.2/guides/source/configuring.md?plain=1#L1354-L1357