### PR TITLE
ActionCableのRedisアダプタのプロトコルを修正

### DIFF
--- a/guides/source/ja/action_cable_overview.md
+++ b/guides/source/ja/action_cable_overview.md
@@ -620,7 +620,7 @@ RedisアダプタではSSL/TLS接続もサポートされています。SSL/TLS�
 ```yaml
 production:
   adapter: redis
-  url: rediss://10.10.3.153:tls_port
+  url: redis://10.10.3.153:tls_port
   channel_prefix: appname_production
   ssl_params: {
     ca_file: "/path/to/ca.crt"


### PR DESCRIPTION
redissからreids://にしました。