### PR TITLE
redisをredissに戻し、注釈を追加

### DIFF
--- a/guides/source/ja/action_cable_overview.md
+++ b/guides/source/ja/action_cable_overview.md
@@ -615,12 +615,12 @@ production:
 Redisアダプタでは、Redisサーバーを指すURLを指定する必要があります。
 また、複数のアプリケーションが同一のRedisサーバーを用いる場合は、チャネル名衝突を避けるために`channel_prefix`の指定が必要になることもあります。詳しくは[Redis Pub/Subドキュメント](https://redis.io/topics/pubsub#database-amp-scoping)を参照してください。
 
-RedisアダプタではSSL/TLS接続もサポートされています。SSL/TLS接続に必要なパラメータは、設定用yamlファイルの`ssl_params`で指定できます。
+RedisアダプタではSSL/TLS接続もサポートされています。SSL/TLS接続に必要なパラメータは、設定用yamlファイルの`ssl_params`で指定できます（注: `rediss://`は[RedisのHTTPS接続](https://github.com/redis/redis-rb/#ssltls-support)を表します）。
 
 ```yaml
 production:
   adapter: redis
-  url: redis://10.10.3.153:tls_port
+  url: rediss://10.10.3.153:tls_port
   channel_prefix: appname_production
   ssl_params: {
     ca_file: "/path/to/ca.crt"


### PR DESCRIPTION
元のプルリク: https://github.com/yasslab/railsguides.jp/pull/1507

`rediss://`はRedisのHTTPS接続用プロトコルとのことなので、上を元に戻し、注釈を追加しました。

ref: https://github.com/rails/rails/pull/49401#issuecomment-1736833727

CIがパスしたらマージします。