### PR TITLE
7.1リリースノートのChangelogへのリンクを更新

### DIFF
--- a/guides/source/ja/7_1_release_notes.md
+++ b/guides/source/ja/7_1_release_notes.md
@@ -980,16 +980,16 @@ Credits
 
 Railsを頑丈かつ安定したフレームワークにするために多大な時間を費やしてくださった多くの開発者については、[Railsコントリビューターの完全なリスト](https://contributors.rubyonrails.org/)を参照してください。これらの方々全員に深く敬意を表明いたします。
 
-[railties]:       https://github.com/rails/rails/blob/main/railties/CHANGELOG.md
-[action-pack]:    https://github.com/rails/rails/blob/main/actionpack/CHANGELOG.md
-[action-view]:    https://github.com/rails/rails/blob/main/actionview/CHANGELOG.md
-[action-mailer]:  https://github.com/rails/rails/blob/main/actionmailer/CHANGELOG.md
-[action-cable]:   https://github.com/rails/rails/blob/main/actioncable/CHANGELOG.md
-[active-record]:  https://github.com/rails/rails/blob/main/activerecord/CHANGELOG.md
-[active-storage]: https://github.com/rails/rails/blob/main/activestorage/CHANGELOG.md
-[active-model]:   https://github.com/rails/rails/blob/main/activemodel/CHANGELOG.md
-[active-support]: https://github.com/rails/rails/blob/main/activesupport/CHANGELOG.md
-[active-job]:     https://github.com/rails/rails/blob/main/activejob/CHANGELOG.md
-[action-text]:    https://github.com/rails/rails/blob/main/actiontext/CHANGELOG.md
-[action-mailbox]: https://github.com/rails/rails/blob/main/actionmailbox/CHANGELOG.md
-[guides]:         https://github.com/rails/rails/blob/main/guides/CHANGELOG.md
+[railties]:       https://github.com/rails/rails/blob/7-1-stable/railties/CHANGELOG.md
+[action-pack]:    https://github.com/rails/rails/blob/7-1-stable/actionpack/CHANGELOG.md
+[action-view]:    https://github.com/rails/rails/blob/7-1-stable/actionview/CHANGELOG.md
+[action-mailer]:  https://github.com/rails/rails/blob/7-1-stable/actionmailer/CHANGELOG.md
+[action-cable]:   https://github.com/rails/rails/blob/7-1-stable/actioncable/CHANGELOG.md
+[active-record]:  https://github.com/rails/rails/blob/7-1-stable/activerecord/CHANGELOG.md
+[active-storage]: https://github.com/rails/rails/blob/7-1-stable/activestorage/CHANGELOG.md
+[active-model]:   https://github.com/rails/rails/blob/7-1-stable/activemodel/CHANGELOG.md
+[active-support]: https://github.com/rails/rails/blob/7-1-stable/activesupport/CHANGELOG.md
+[active-job]:     https://github.com/rails/rails/blob/7-1-stable/activejob/CHANGELOG.md
+[action-text]:    https://github.com/rails/rails/blob/7-1-stable/actiontext/CHANGELOG.md
+[action-mailbox]: https://github.com/rails/rails/blob/7-1-stable/actionmailbox/CHANGELOG.md
+[guides]:         https://github.com/rails/rails/blob/7-1-stable/guides/CHANGELOG.md


### PR DESCRIPTION
CIがパスしたらマージします。
原文も更新されていなかったので、後で本家にもプルリクします。