### PR TITLE
Rails 7.1.1に沿って訳文を更新

### DIFF
--- a/guides/source/ja/active_storage_overview.md
+++ b/guides/source/ja/active_storage_overview.md
@@ -589,7 +589,7 @@ WARNING: Active Storageのすべてのコントローラは、デフォルトで
 
 ```ruby
 url_for(user.avatar)
-# => /rails/active_storage/blobs/:signed_id/my-avatar.png
+# => https://www.example.com/rails/active_storage/blobs/redirect/:signed_id/my-avatar.png
 ```
 
 `RedirectController`は、サービスの実際のエンドポイントにリダイレクトします。この間接参照によってサービスURLと実際のURLが切り離され、たとえば添付ファイルを別サービスにミラーリングして可用性を高めることが可能になります。リダイレクトのHTTP有効期限は5分です。

--- a/guides/source/ja/active_support_instrumentation.md
+++ b/guides/source/ja/active_support_instrumentation.md
@@ -9,7 +9,6 @@ Active SupportはRailsのコア機能の1つであり、Ruby言語の拡張、�
 
 * Instrumentationでできること
 * Railsフレームワーク内のInstrumentationフック
-* Instrumentationで得たタイミング情報をブラウザで表示する
 * フックにサブスクライバを追加する
 * 独自のInstrumentationを実装する
 
@@ -87,21 +86,6 @@ ActiveSupport::Notifications.subscribe(/action_controller/) do |*args|
   # ActionControllerの全イベントをチェック
 end
 ```
-
-[`ActiveSupport::Notifications::Event`]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications/Event.html
-[`ActiveSupport::Notifications.monotonic_subscribe`]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html#method-c-monotonic_subscribe
-[`ActiveSupport::Notifications.subscribe`]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html#method-c-subscribe
-
-Instrumentationで得たタイミング情報をブラウザで表示する
--------------------------------------------------
-
-Railsは、[Server Timing](https://www.w3.org/TR/server-timing/)標準を実装して、タイミング情報をWebブラウザで表示可能にしています。これを有効にするには、環境設定（development環境で使うことが最も多いので、通常は`development.rb`にします）を編集し、以下の内容を追加します。
-
-```ruby
-config.server_timing = true
-```
-
-設定（およびサーバーの再起動など）が完了したら、ブラウザのDevToolsパネルを開き、Networkタブを選択してページを再読み込みします。これで、Railsサーバーへの任意のリクエストを選択すると、Timingタブにサーバータイミングが表示されるようになります。操作方法の例については、[Firefoxドキュメント](https://firefox-source-docs.mozilla.org/devtools-user/network_monitor/request_details/index.html#server-timing)を参照してください。
 
 [`ActiveSupport::Notifications::Event`]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications/Event.html
 [`ActiveSupport::Notifications.monotonic_subscribe`]: https://api.rubyonrails.org/classes/ActiveSupport/Notifications.html#method-c-monotonic_subscribe

--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -540,7 +540,7 @@ config.railties_order = [Blog::Engine, :main_app, :all]
 
 #### `config.server_timing`
 
-`true`にすると、[ServerTimingミドルウェア](#actiondispatch-servertiming)をミドルウェアスタックに追加します。
+`true`にすると、[ServerTimingミドルウェア](#actiondispatch-servertiming)をミドルウェアスタックに追加します。デフォルトは`false`ですが、生成されるデフォルトの`config/environments/development.rb`ファイルでは`true`に設定されます。
 
 #### `config.session_options`
 
@@ -757,7 +757,9 @@ Rails.application.config.host_authorization = {
 
 #### `ActionDispatch::ServerTiming`
 
-`Server-Timing`ヘッダーにメトリクスを追加して、ブラウザのDevToolsで参照できるようにします。
+サーバーのパフォーマンスメトリクスを含む[`Server-Timing`][]ヘッダーをレスポンスに追加します。このデータは、ブラウザのDevToolsの「Network」ペインでレスポンスを調べることで確認できます。ほとんどのブラウザには、このデータを可視化する「Timing」タブがあります。
+
+[`Server-Timing`]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Server-Timing
 
 #### `ActionDispatch::SSL`
 
@@ -1673,6 +1675,15 @@ Rendered messages/_message.html.erb in 1.2 ms [cache hit]
 Rendered recordings/threads/_thread.html.erb in 1.5 ms [cache miss]
 ```
 
+#### `config.action_controller.raise_on_missing_callback_actions`
+
+コールバックの`:only`オプションや`:except`オプションで指定したアクションがコントローラ内に存在しない場合に`AbstractController::ActionNotFound`をraiseするかどうかを指定します。
+
+| バージョン              | デフォルト値           |
+| --------------------- | -------------------- |
+| （オリジナル）           | `false`              |
+| 7.1                   | `true`（developmentとtest）、`false`（その他の環境）|
+
 #### `config.action_controller.raise_on_open_redirects`
 
 許可されていないオープンリダイレクトが発生した場合に`ActionController::Redirecting::UnsafeRedirectError`をraiseします。
@@ -1730,7 +1741,7 @@ cookieで使うシリアライザを指定します。[`config.active_support.me
 
 #### `config.action_dispatch.debug_exception_log_level`
 
-リクエスト中にキャッチされない例外をログ出力する際に、DebugExceptionsミドルウェアで使うログレベルを設定します。
+リクエスト中にキャッチされない例外をログ出力する際に、[`ActionDispatch::DebugExceptions`]ミドルウェアで使うログレベルを設定します。
 
 デフォルト値は、`config.load_defaults`のターゲットバージョンによって異なります。
 
@@ -1738,6 +1749,8 @@ cookieで使うシリアライザを指定します。[`config.active_support.me
 | --------------------- | -------------------- |
 | （オリジナル）           | `:fatal`             |
 | 7.1以降                | `:error`             |
+
+[`ActionDispatch::DebugExceptions`]: https://api.rubyonrails.org/classes/ActionDispatch/DebugExceptions.html
 
 #### `config.action_dispatch.default_headers`
 

--- a/guides/source/ja/upgrading_ruby_on_rails.md
+++ b/guides/source/ja/upgrading_ruby_on_rails.md
@@ -267,7 +267,39 @@ ActiveSupport.on_load :action_view_test_case do
 end
 ```
 
-[`assert_match``]: https://docs.seattlerb.org/minitest/Minitest/Assertions.html#method-i-assert_match
+### `Rails.logger`が`ActiveSupport::BroadcastLogger`インスタンスを返すようになった
+
+新しい`ActiveSupport::BroadcastLogger`クラスを使うと、ログを手軽にさまざまな出力先（STDOUT、ログファイルなど）にブロードキャストできるようになります。
+
+`ActiveSupport::Logger.broadcast` privateメソッドを用いる従来のログブロードキャストAPIは削除されました。
+アプリケーションがこのAPIに依存している場合は、以下のような変更が必要です。
+
+```ruby
+logger = Logger.new("some_file.log")
+
+# 変更前
+
+Rails.logger.extend(ActiveSupport::Logger.broadcast(logger))
+
+# 変更後
+
+Rails.logger.broadcast_to(logger)
+```
+
+アプリケーションでカスタムロガーを利用している場合は、すべてのメソッドが`Rails.logger`にラップおよびプロキシされるので、特に変更は必要ありません。
+
+カスタムロガーのインスタンスにアクセスする必要がある場合は、以下のように`broadcasts`メソッドでアクセスできます。
+
+```ruby
+# config/application.rb
+config.logger = MyLogger.new
+
+# アプリケーションのどこでも利用できる
+puts Rails.logger.class      #=> BroadcastLogger
+puts Rails.logger.broadcasts #=> [MyLogger]
+```
+
+[`assert_match`]: https://docs.seattlerb.org/minitest/Minitest/Assertions.html#method-i-assert_match
 
 Rails 6.1からRails 7.0へのアップグレード
 -------------------------------------


### PR DESCRIPTION
https://github.com/rails/rails/releases/tag/v7.1.1 がリリースされました。

先に反映すべき更新を反映しました。残りも追ってプルリクします。
CIがパスしたらマージします。