### PR TITLE
5_0_release_notes にある i18n を I18n に変更

### DIFF
--- a/guides/source/ja/5_0_release_notes.md
+++ b/guides/source/ja/5_0_release_notes.md
@@ -385,7 +385,7 @@ Action View
 *  `ActionView::Helpers::RecordTagHelper`を削除。この機能は[record_tag_helper](https://github.com/rails/record_tag_helper) gemに移行済み。
     ([Pull Request](https://github.com/rails/rails/pull/18411))
 
-*  i18nでのサポート廃止に伴い、`translate`の`:rescue_format`オプションを削除。
+*  I18nでのサポート廃止に伴い、`translate`の`:rescue_format`オプションを削除。
     ([Pull Request](https://github.com/rails/rails/pull/20019))
 
 ### 主な変更点
@@ -423,7 +423,7 @@ Action Mailer
 
 ### 主な変更点
 
-*   テンプレートを検索するときにデフォルトのロケールとi18nにフォールバックするようになった。
+*   テンプレートを検索するときにデフォルトのロケールとI18nにフォールバックするようになった。
     ([commit](https://github.com/rails/rails/commit/ecb1981b))
 
 *  ジェネレーターで生成されたメーラーに`_mailer`サフィックスを追加。コントローラやジョブと同様の命名規則に従う。


### PR DESCRIPTION
## やったこと
- [x] 5_0_release_notes.md を原文に沿って、i18n -> I18n に変更
  - https://github.com/yasslab/railsguides.jp/blob/9b77dbae3e22a420edbf32e72e219fa737a658c2/guides/source/5_0_release_notes.md?plain=1#L479
  -  https://github.com/yasslab/railsguides.jp/blob/9b77dbae3e22a420edbf32e72e219fa737a658c2/guides/source/5_0_release_notes.md?plain=1#L523