### PR TITLE
MySQLの実行計画結果をPostgreSQLの場合と記載してあった問題を修正

### DIFF
--- a/guides/source/ja/active_record_querying.md
+++ b/guides/source/ja/active_record_querying.md
@@ -2629,7 +2629,7 @@ MySQLまたはMariaDBの場合は、以下のようになります。
 Customer.where(id: 1).joins(:orders).explain(:analyze)
 ```
 
-PostgreSQLの場合は以下のようになります。
+上のコードは以下を生成します。
 
 ```sql
 ANALYZE SELECT `shop_accounts`.* FROM `shop_accounts` INNER JOIN `customers` ON `customers`.`id` = `shop_accounts`.`customer_id` WHERE `shop_accounts`.`id` = 1


### PR DESCRIPTION

下記のURLページでMySQLの実行結果を`PostgreSQLの場合は`と記載があったので修正しました。

https://railsguides.jp/active_record_querying.html#%E5%8B%95%E7%9A%84%E6%A4%9C%E7%B4%A2

<img width="696" alt="image" src="https://github.com/yasslab/railsguides.jp/assets/45971/99d32f32-004a-44c9-a9b8-7333a04459ce">

---

`PostgreSQLの場合は`の記載は下記の箇所にあり、そこでは`上のコードは以下を生成します。`とあったのでそれに合わせて変更しました。

<img width="680" alt="image" src="https://github.com/yasslab/railsguides.jp/assets/45971/8c4e467c-d12f-4e17-be83-966442756b99">
