### PR TITLE
「Action Controller の概要」ページの「リソースルーティング」への内部リンクを修正

### DIFF
--- a/guides/source/ja/action_controller_overview.md
+++ b/guides/source/ja/action_controller_overview.md
@@ -72,7 +72,7 @@ WARNING: 一部のメソッド名はAction Controllerで予約されています
 NOTE: 予約済みメソッド名をアクション名として使わざるを得ない場合は、たとえばカスタムルーティングを利用して、予約済みメソッド名を予約されていないアクションメソッド名に対応付けるという回避策が考えられます。
 
 [`ActionController::Base`]: https://api.rubyonrails.org/classes/ActionController/Base.html
-[Resource Routing]: routing.html#リソースベースのルーティング-railsのデフォルト
+[リソースルーティング]: routing.html#リソースベースのルーティング-railsのデフォルト
 
 パラメータ
 ----------


### PR DESCRIPTION
[Action Controller の概要](https://railsguides.jp/action_controller_overview.html)ページ内の「リソースルーティング」への内部リンクがうまく張れていなかったようなので、修正しました。
ローカル環境で動作確認済みです。