### PR TITLE
「Rails テスティングガイド」ページの「RSS コンテンツ」への内部リンクの修正

### DIFF
--- a/guides/source/ja/testing.md
+++ b/guides/source/ja/testing.md
@@ -1832,7 +1832,7 @@ end
 ```
 
 [rails-dom-testing]: https://github.com/rails/rails-dom-testing
-[RSS content]: https://www.rssboard.org/rss-specification
+[RSS コンテンツ]: https://www.rssboard.org/rss-specification
 
 ヘルパーをテストする
 ---------------


### PR DESCRIPTION
「[Rails テスティングガイド](https://railsguides.jp/testing.html)」ページの「RSS コンテンツ」への内部リンクの修正を行いました。
ローカルでの動作確認済みです。
