### PR TITLE
リンクの生成がうまくできていないところを修正

### DIFF
--- a/guides/source/ja/action_controller_overview.md
+++ b/guides/source/ja/action_controller_overview.md
@@ -72,7 +72,7 @@ WARNING: 一部のメソッド名はAction Controllerで予約されています
 NOTE: 予約済みメソッド名をアクション名として使わざるを得ない場合は、たとえばカスタムルーティングを利用して、予約済みメソッド名を予約されていないアクションメソッド名に対応付けるという回避策が考えられます。
 
 [`ActionController::Base`]: https://api.rubyonrails.org/classes/ActionController/Base.html
-[Resource Routing]: routing.html#リソースベースのルーティング-railsのデフォルト
+[リソースルーティング]: routing.html#リソースベースのルーティング-railsのデフォルト
 
 パラメータ
 ----------

--- a/guides/source/ja/contributing_to_ruby_on_rails.md
+++ b/guides/source/ja/contributing_to_ruby_on_rails.md
@@ -99,7 +99,7 @@ GitHub Issuesは「機能リクエスト」の場ではありません。Ruby on
 
 機能追加用のパッチを送信する前に自分のアイデアに意見を募りたい場合は、最初にdiscuss.rubyonrails.orgというSNSの[rubyonrails-core][]に投稿してみてください。もし反応がなければ自分のアイデアに誰も関心を持っていないことがわかりますし、自分のアイデアに興味を示した人が反応する可能性もあります。場合によっては「残念ながら採用できません」という返信があるかもしれません。しかしこのSNSこそ、そうしたアイデアについて議論するための場所なのです。逆にGitHubのissueは、こうした新しいアイデアで必要な議論（ときには長期かつ複雑になることもあるでしょう）を行う場としては不向きです。
 
-[rubyonrails-core](https://discuss.rubyonrails.org/c/rubyonrails-core)
+[rubyonrails-core]: https://discuss.rubyonrails.org/c/rubyonrails-core
 
 既存のissueの解決を手伝う
 ----------------------------------

--- a/guides/source/ja/form_helpers.md
+++ b/guides/source/ja/form_helpers.md
@@ -270,7 +270,7 @@ TIP: 通常、inputにはモデルの属性が反映されます。しかしこ�
 生成されたURLには、`author_id`と`id`がアンダースコア区切りの形で含まれていることにご注目ください。
 送信後、コントローラーはパラメータから[個別の主キーの値を抽出][]して、単一の主キーと同様にレコードを更新できます。
 
-[extract each primary key value]: action_controller_overview.html#複合主キーのパラメータ
+[個別の主キーの値を抽出]: action_controller_overview.html#複合主キーのパラメータ
 
 #### `fields_for`ヘルパー
 

--- a/guides/source/ja/testing.md
+++ b/guides/source/ja/testing.md
@@ -1832,7 +1832,7 @@ end
 ```
 
 [rails-dom-testing]: https://github.com/rails/rails-dom-testing
-[RSS content]: https://www.rssboard.org/rss-specification
+[RSS コンテンツ]: https://www.rssboard.org/rss-specification
 
 ヘルパーをテストする
 ---------------

--- a/guides/source/ja/upgrading_ruby_on_rails.md
+++ b/guides/source/ja/upgrading_ruby_on_rails.md
@@ -251,7 +251,7 @@ I18n.t("missing.key") # 7.0/7.1どちらもraiseしない
 
 ### `ActionView::TestCase#rendered`が`String`を返さなくなった
 
-Rails 7.1から、`ActionView::TestCase#rendered`はさまざまなフォーマットメソッドに応答するオブジェクト（`rendered.html`や`rendered.json`など）を返すようになります。後方互換性を維持するために、`rendered`から返されるオブジェクトは、テスト中にレンダリングされる"missing"メソッドを`String`に委譲します。たとえば、以下の[`assert_match``][]アサーションはパスします。
+Rails 7.1から、`ActionView::TestCase#rendered`はさまざまなフォーマットメソッドに応答するオブジェクト（`rendered.html`や`rendered.json`など）を返すようになります。後方互換性を維持するために、`rendered`から返されるオブジェクトは、テスト中にレンダリングされる"missing"メソッドを`String`に委譲します。たとえば、以下の[`assert_match`][]アサーションはパスします。
 
 ```ruby
 assert_match(/some content/i, rendered)


### PR DESCRIPTION
ドキュメント内でうまくリンクが張れていなかったところを複数見つけたので修正しました。
全てローカルで動作確認済みです。

※ 元々個別に修正PRを作っていましたが一つにまとめました 🙇 