### PR TITLE
日本語訳と原文が重複して表示されていた問題を修正

### DIFF
--- a/guides/source/ja/6_0_release_notes.md
+++ b/guides/source/ja/6_0_release_notes.md
@@ -720,8 +720,6 @@ Active Support
     ([Pull Request](https://github.com/rails/rails/pull/32185))
 
 *   入力でUnicode文字とエスケープ文字が混在している場合に`URI.unescape`が失敗するバグを修正
-*   Fix bug where `URI.unescape` would fail with mixed Unicode/escaped character
-    input.
     ([Pull Request](https://github.com/rails/rails/pull/32183))
 
 *   圧縮が有効な場合に`ActiveSupport::Cache`のストレージサイズが激増するバグを修正


### PR DESCRIPTION
## 概要

[Rails 6.0リリースノート 11.3](https://railsguides.jp/6_0_release_notes.html#active-support-%E4%B8%BB%E3%81%AA%E5%A4%89%E6%9B%B4 )において、日本語訳と原文が重複して表示されていた箇所がありました。

このPRでは、該当記事のmarkdown から英文箇所を削除することで、日本語訳のみが表示されるように修正しています。




