### PR TITLE
typoの修正

### DIFF
--- a/guides/source/ja/action_mailer_basics.md
+++ b/guides/source/ja/action_mailer_basics.md
@@ -657,7 +657,7 @@ class UserMailer < ApplicationMailer
 end
 ```
 
-* `after_delivery`はメッセージ配信を記録するのに利用できます。
+* `after_deliver`はメッセージ配信を記録するのに利用できます。
     オブザーバーやインターセプタのような振る舞いも可能ですが、メーラーのコンテキスト全体にアクセスできる点が優れています。
 
 ```ruby


### PR DESCRIPTION
after_delivery -> after_deliver

原著: https://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-callbacks

> You could use an after_deliver to record the delivery of the message. It also allows observer/interceptor-like behaviors, but with access to the full mailer context.