### PR TITLE
fix typo `show_Exceptions` -> `show_exceptions`

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -1918,7 +1918,7 @@ end
 
 #### `config.action_dispatch.show_exceptions`
 
-`config.action_dispatch.show_Exceptions`設定は、リクエストへの応答中にAction Pack（具体的には[`ActionDispatch::ShowExceptions`](/configuring.html#actiondispatch-showexceptions)ミドルウェア）が発生した例外を処理する方法を指定します。
+`config.action_dispatch.show_exceptions`設定は、リクエストへの応答中にAction Pack（具体的には[`ActionDispatch::ShowExceptions`](/configuring.html#actiondispatch-showexceptions)ミドルウェア）が発生した例外を処理する方法を指定します。
 
 値を`:all`または`true`に設定すると、例外をrescueして対応するエラーページを表示するようにAction Packを構成します。たとえば、Action Packは `ActiveRecord::RecordNotFound`例外をrescueし、`public/404.html`にあるコンテンツをステータスコード`404 Not found`でレンダリングします。
 

--- a/guides/source/ja/upgrading_ruby_on_rails.md
+++ b/guides/source/ja/upgrading_ruby_on_rails.md
@@ -355,7 +355,7 @@ config.active_record.encryption.support_sha1_for_non_deterministic_encryption = 
 `config.action_dispatch.show_exceptions`設定は、リクエストへの応答中に発生した例外をAction Packで処理する方法を制御します。
 
 Rails 7.1より前のAction Packでは、`config.action_dispatch.show_exceptions = true`を設定すると、例外をrescueして適切なHTMLエラーページをレンダリングするように設定されていました（例: `ActiveRecord::RecordNotFound`例外をraiseするのではなく、`public/404.html`をステータスコード`404 Not found`でレンダリングする）。
-`config.action_dispatch.show_exceptions = false`を設定すると、例外をrescueしないようにAction Packが設定されました。Rails 7.1より前の新しいアプリケーションでは、生成された`config/environments/test.rb`内で`config.action_dispatch.show_Exceptions = false`が設定されていました。
+`config.action_dispatch.show_exceptions = false`を設定すると、例外をrescueしないようにAction Packが設定されました。Rails 7.1より前の新しいアプリケーションでは、生成された`config/environments/test.rb`内で`config.action_dispatch.show_exceptions = false`が設定されていました。
 
 Rails 7.1では、この設定に渡せる値が`true`と`false`から、`:all`と`:rescuable`と`:none`に変更されました。
 
@@ -363,7 +363,7 @@ Rails 7.1では、この設定に渡せる値が`true`と`false`から、`:all`�
 * `:rescuable`: [`config.action_dispatch.rescue_responses`](/configuring.html#config-action-dispatch-rescue-responses)で宣言されている例外についてはHTMLエラーページを表示する
 * `:none`（`false`と同等）: 例外をrescueしない
 
-Rails 7.1以降で生成したアプリケーションの`config/environments/test.rb`には `config.action_dispatch.show_Exceptions = :rescuable`が設定されます。アップグレードする場合、既存のアプリケーションの`config.action_dispatch.show_exceptions = :rescuable`を新しい振る舞いに沿って変更することも、古い値を対応する新しい値に置き換える（`true`を`:all`に置き換え、`false`を`:none`に置き換える）ことも可能です。
+Rails 7.1以降で生成したアプリケーションの`config/environments/test.rb`には `config.action_dispatch.show_exceptions = :rescuable`が設定されます。アップグレードする場合、既存のアプリケーションの`config.action_dispatch.show_exceptions = :rescuable`を新しい振る舞いに沿って変更することも、古い値を対応する新しい値に置き換える（`true`を`:all`に置き換え、`false`を`:none`に置き換える）ことも可能です。
 
 Rails 6.1からRails 7.0へのアップグレード
 -------------------------------------


### PR DESCRIPTION
I have changed tiny typos. These were not included in the original documents in the following link.

- https://guides.rubyonrails.org/configuring.html#config-action-dispatch-show-exceptions
- https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#new-ways-to-handle-exceptions-in-controller-tests-integration-tests-and-system-tests

Thank you in advance :)