### PR TITLE
コードスパンの記述ミスにより誤ったマークアップになっているのを修正

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -930,7 +930,7 @@ config.middleware.delete Rack::MethodOverride
 
 [`Error#full_message`][ActiveModel::Error#full_message]エラーフォーマットをi18nのロケールファイルで上書きしてよいかどうかを制御するboolean値です。デフォルト値は`false`です。
 
-`true`に設定すると、`full_message`はロケールファイルの属性とモデルレベルでフォーマットを探索します。デフォルトのフォーマットは`"%{attribute} %{message}"で、`attribute`は属性名、`message`はバリデーション固有のメッセージです。以下の例では、すべての `Person`属性と、特定の`Person`属性（`age`）のフォーマットをオーバーライドしています。
+`true`に設定すると、`full_message`はロケールファイルの属性とモデルレベルでフォーマットを探索します。デフォルトのフォーマットは`"%{attribute} %{message}"`で、`attribute`は属性名、`message`はバリデーション固有のメッセージです。以下の例では、すべての `Person`属性と、特定の`Person`属性（`age`）のフォーマットをオーバーライドしています。
 
 ```ruby
 class Person


### PR DESCRIPTION
バッククォートが一つ足りていませんでした。
https://railsguides.jp/configuring.html#active-model%E3%82%92%E8%A8%AD%E5%AE%9A%E3%81%99%E3%82%8B

----

BEFORE

<img width="677" alt="before" src="https://github.com/yasslab/railsguides.jp/assets/500072/88b38dba-ab66-41ee-a26a-e07d448abcb6">

----

AFTER
<img width="1062" alt="after" src="https://github.com/yasslab/railsguides.jp/assets/500072/a80b7b11-2107-45db-8e2b-9d7621770470">

