### PR TITLE
EXPLAINの利用のドキュメントのバージョンを現在のPostgreSQL日本語最新版のバージョンに明示的に指定

### DIFF
--- a/guides/source/ja/active_record_querying.md
+++ b/guides/source/ja/active_record_querying.md
@@ -2662,4 +2662,4 @@ EXPLAINの出力を解釈することは、本ガイドの範疇を超えます�
 
 * MariaDB: [EXPLAIN](https://mariadb.com/kb/en/explain/)
 
-* PostgreSQL: [EXPLAINの利用](https://www.postgresql.jp/document/current/html/using-explain.html) （v13日本語）
+* PostgreSQL: [EXPLAINの利用](https://www.postgresql.jp/document/15/html/using-explain.html) （v15日本語）


### PR DESCRIPTION
ドキュメントのリンクを `https://www.postgresql.jp/document/current/html/using-explain.html`と書くと、
PostgtreSQLの新しいバージョンが出るたびに `v13` の部分を変える必要があるので、
ドキュメントのバージョンを明示的に指定したリンクに変更しました。

リンクは `https://www.postgresql.jp/document/current/html/using-explain.html` のままで、
バージョン情報を消すのも手かもしれませんが、[ja-7.0](https://github.com/yasslab/railsguides.jp/blob/ja-7.0/guides/source/ja/active_record_querying.md) で13にバージョンが明示されているので、そちらに合わせる形にしました。
