### PR TITLE
バリデーションガイドのカスタムバリデータのコードを修正

### DIFF
--- a/guides/source/ja/active_record_validations.md
+++ b/guides/source/ja/active_record_validations.md
@@ -991,7 +991,7 @@ end
 ```ruby
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+    unless URI::MailTo::EMAIL_REGEXP.match?(value)
       record.errors.add attribute, (options[:message] || "はメールアドレスではありません")
     end
   end


### PR DESCRIPTION
https://guides.rubyonrails.org/active_record_validations.html#custom-validators

7.1で更新された原文の反映漏れを修正しました。

```diff
class EmailValidator < ActiveModel::EachValidator
  def validate_each(record, attribute, value)
-  unless value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+  unless URI::MailTo::EMAIL_REGEXP.match?(value)
  record.errors.add attribute, (options[:message] || "はメールアドレスではありません")
  end
end
```

CIがパスしたらマージします。