### PR TITLE
ActiveRecord EncryptionのダイジェストアルゴリズムのデフォルトをSHA256に変更

### DIFF
--- a/guides/source/ja/active_record_encryption.md
+++ b/guides/source/ja/active_record_encryption.md
@@ -497,7 +497,7 @@ rootデータ暗号化キーの導出に用いるキーまたはキーのリス�
 
 #### `config.active_record.encryption.hash_digest_class`
 
-鍵の導出に使うダイジェストアルゴリズムです。デフォルトは`OpenSSL::Digest::SHA1`です。
+鍵の導出に使うダイジェストアルゴリズムです。デフォルトは`OpenSSL::Digest::SHA256`です。
 
 #### `config.active_record.encryption.support_sha1_for_non_deterministic_encryption`
 


### PR DESCRIPTION
Rails7.1でのダイジェストアルゴリズムのデフォルトはSHA256でした。
https://github.com/rails/rails/blob/8ad19d986519ee84c22a4a02368726616b41abd7/guides/source/upgrading_ruby_on_rails.md?plain=1#L333-L334

手元でも確認しています。
```ruby
irb(main):001> Rails.configuration.active_record.encryption.hash_digest_class
=> OpenSSL::Digest::SHA256
irb(main):002> ActiveRecord::Encryption.config.hash_digest_class
=> OpenSSL::Digest::SHA256
```