### PR TITLE
文字列リテラルのシングルクォートの閉じ忘れを修正

### DIFF
--- a/guides/source/ja/routing.md
+++ b/guides/source/ja/routing.md
@@ -1108,7 +1108,7 @@ resources :photos
 ```
 
 上のように`as:`を使うと、`/admin/photos`のルーティングヘルパーが、`photos_path`、`new_photos_path`などから`admin_photos_path`、`new_admin_photo_path`などに変更されます。
-`as: 'admin_photos`をスコープ付き`resources :photos`に追加しない場合は、スコープなしの`resources :photos`はルーティングヘルパーを持つことができません。
+`as: 'admin_photos'`をスコープ付き`resources :photos`に追加しない場合は、スコープなしの`resources :photos`はルーティングヘルパーを持つことができません。
 
 ルーティングヘルパーのグループにまとめてプレフィックスを追加するには、以下のように`scope`メソッドで`:as`オプションを使います。
 


### PR DESCRIPTION
シングルクォートの閉じ忘れと思われる箇所を修正いたしました。

`as: 'admin_photos`を... -> `as: 'admin_photos'`を...