### PR TITLE
Fix missing backquotes

### DIFF
--- a/guides/source/ja/active_record_postgresql.md
+++ b/guides/source/ja/active_record_postgresql.md
@@ -381,7 +381,7 @@ SELECT n.nspname AS enum_schema,
 * [pgcryptoのジェネレータ関数][pgcrypto]
 * [uuid-osspのジェネレータ関数][uuid_ossp]
 
-NOTE: バージョン13.0より前のPostgreSQLを使っている場合は、UUIDを利用するために特別な拡張機能を有効にする必要が生じる場合があります。pgcrypto`拡張機能（PostgreSQL 9.4以上）または`uuid-ossp`拡張機能 (それ以前のバージョン) を有効にしてください。
+NOTE: バージョン13.0より前のPostgreSQLを使っている場合は、UUIDを利用するために特別な拡張機能を有効にする必要が生じる場合があります。`pgcrypto`拡張機能（PostgreSQL 9.4以上）または`uuid-ossp`拡張機能 (それ以前のバージョン) を有効にしてください。
 
 ```ruby
 # db/migrate/20131220144913_create_revisions.rb


### PR DESCRIPTION
「`」（バッククォート）が不足していることに気付き修正しました。

## 現状の日本語版
現状は、`拡張機能（PostgreSQL 9.4以上）または`が強調されており、uuid-ossp の後ろに 「`」が付いていました。

<img width="800" alt="スクリーンショット 2024-09-12 15 41 28" src="https://github.com/user-attachments/assets/3990905c-9f1a-47c7-8a6b-010eaa4ee234">

https://railsguides.jp/active_record_postgresql.html#uuid


## 本家
本家では `pgcrypto`, `uuid-ossp` が強調されていたのでそれに合わせて修正しました。
<img width="800" alt="スクリーンショット 2024-09-12 15 37 35" src="https://github.com/user-attachments/assets/05cbe36f-fdec-4d2b-933a-4290bcaac035">

https://guides.rubyonrails.org/active_record_postgresql.html#uuid