### PR TITLE
6.1と3.2のリリースノートで軽微な修正

### DIFF
--- a/guides/source/ja/3_2_release_notes.md
+++ b/guides/source/ja/3_2_release_notes.md
@@ -358,7 +358,7 @@ Client.where(:active => true).pluck(:id)
 
 * 関連付けメソッドの生成は、独立した1つのモジュール内で作成されるようになりました。これはオーバーライドやコンポジションできるようにするためです。たとえば`MyModel`というクラスがあり、そのモジュールが`MyModel::GeneratedFeatureMethods`だとします。Active Modelで定義された`generated_attributes_methods`が実行されると、このモジュールはただちにそのモデルクラスにincludeされるので、関連付けメソッドは同じ名前の属性メソッドをオーバーライドします。
 
-* 一意のクエリを生成する`ActiveRecord::Relation#uniq``ActiveRecord::Relation#uniq`が追加されました。
+* 一意のクエリを生成する`ActiveRecord::Relation#uniq`が追加されました。
 
     ```ruby
     Client.select('DISTINCT name')

--- a/guides/source/ja/6_1_release_notes.md
+++ b/guides/source/ja/6_1_release_notes.md
@@ -23,7 +23,7 @@ Rails 6.1へのアップグレード
 
 ### データベース単位のコネクション切り替え
 
-Rails 6.1でデータベース単位のコネクション切り替え機能が使えるようになりました（[#40370](https://github.com/rails/rails/pull/40370)。6.0の場合は、ロールを`reading`に切り替えるとすべてのデータベースコネクションもreadingロールに切り替わりました。6.1からは、Railsの設定で`legacy_connection_handling`を`false`に指定しておけば、対応する抽象クラスで`connected_to`を呼び出すことでデータベースへのコネクションを切り替えられます。
+Rails 6.1でデータベース単位のコネクション切り替え機能が使えるようになりました（[#40370](https://github.com/rails/rails/pull/40370)）。6.0の場合は、ロールを`reading`に切り替えるとすべてのデータベースコネクションもreadingロールに切り替わりました。6.1からは、Railsの設定で`legacy_connection_handling`を`false`に指定しておけば、対応する抽象クラスで`connected_to`を呼び出すことでデータベースへのコネクションを切り替えられます。
 
 ### 水平シャーディング
 


### PR DESCRIPTION
## やったこと

6.1と3.2のリリースノートで軽微な修正を行いました
テストが通ったらマージします🙏

### 6.1 リリースノート
- 閉じカッコを追加

🔽 修正前
![閉じカッコを入れたい](https://github.com/user-attachments/assets/aca04ad4-1cab-435e-8b9e-403e1d2fe498)

🔽 修正後
![スクリーンショット 2024-10-07 17 24 29](https://github.com/user-attachments/assets/b490faef-94bc-4afa-b077-7f34547549ac)


### 3.2リリースノート
- 重複をカット

🔽 修正前
![重複をカット](https://github.com/user-attachments/assets/63d3ef8f-fea8-4b6f-9ddd-44ee0db54622)

🔽 修正後
![スクリーンショット 2024-10-07 17 25 48](https://github.com/user-attachments/assets/858eb985-a193-49f6-bf7f-33b754ea6ff7)
