### PR TITLE
getting_started_with_devcontainer.mdの簡単なtypo修正

### DIFF
--- a/guides/source/ja/getting_started_with_devcontainer.md
+++ b/guides/source/ja/getting_started_with_devcontainer.md
@@ -39,7 +39,7 @@ dev container拡張機能は、[マーケットプレイス](https://marketplace
 
 `rails-new`ツールを使うと、自分のコンピュータにRubyがインストールされていなくても新規Railsアプリケーションを生成できるようになります。Dockerを利用してRailsアプリケーションを生成するため、適切なバージョンのRubyやRailsをDockerでインストールできるようになります。
 
-`Rails-new`ツールをインストールするには、[README](https://github.com/rails/rails-new?tab=readme-ov-file#installation)のインストール手順に従ってください。
+`rails-new`ツールをインストールするには、[README](https://github.com/rails/rails-new?tab=readme-ov-file#installation)のインストール手順に従ってください。
 
 ブログアプリケーションを作成する
 -----------------------------
@@ -54,7 +54,7 @@ NOTE: 以下の例では、UNIX系 OSのターミナルプロンプトを`$`で�
 $ rails-new blog --devcontainer
 ```
 
-これによって`blog`ディレクトリが作成され、その中に`Blog`という名前のRailsアプリケーションが作成されます。
+これによって`blog`ディレクトリが作成され、その中にBlogという名前のRailsアプリケーションが作成されます。
 
 TIP: `rails-new --help`を実行すると、Railsのアプリケーションジェネレータに渡せるのと同じコマンドラインオプションが表示されていることがわかります。
 


### PR DESCRIPTION
本家最新版：
https://github.com/rails/rails/blob/b8720e7cb8c9894d142b8576c21065c92cd1907a/guides/source/getting_started_with_devcontainer.md

偶然見つけた、`rails-new`に関する簡単なtypo修正です。