### PR TITLE
新ガイドで不要な冒頭の注意文をカット

### DIFF
--- a/guides/source/ja/7_2_release_notes.md
+++ b/guides/source/ja/7_2_release_notes.md
@@ -1,5 +1,3 @@
-**DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**
-
 Ruby on Rails 7.2 リリースノート
 ===============================
 

--- a/guides/source/ja/getting_started_with_devcontainer.md
+++ b/guides/source/ja/getting_started_with_devcontainer.md
@@ -1,5 +1,3 @@
-**DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**
-
 Dev Containerでの開発ガイド
 ===================================
 

--- a/guides/source/ja/tuning_performance_for_deployment.md
+++ b/guides/source/ja/tuning_performance_for_deployment.md
@@ -1,5 +1,3 @@
-**DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**
-
 デプロイ用パフォーマンスチューニング
 =================================
 


### PR DESCRIPTION
以下のガイドで、他のガイドと同様に、冒頭の `**DO NOT READ THIS FILE ON GITHUB, GUIDES ARE PUBLISHED ON https://guides.rubyonrails.org.**` 部分をカットしました✂️

- 7_2_release_notes.md
- getting_started_with_devcontainer.md
- tuning_performance_for_deployment.md

CIがパスしたらマージします🙏