### PR TITLE
電子書籍でバグが起こるためコメントを削除

### DIFF
--- a/guides/source/ja/upgrading_ruby_on_rails.md
+++ b/guides/source/ja/upgrading_ruby_on_rails.md
@@ -452,7 +452,6 @@ ActiveSupport::Dependencies.constantize("User") # 今後は利用不可
 
 * オートローダーの動作をトレースしたい場合、`ActiveSupport::Dependencies.verbose=`は利用できなくなりました。`config/application.rb`で`Rails.autoloaders.log!`をスローしてください。
 
-<!-- ビルド対応として改行を追加 -->
 `ActiveSupport::Dependencies::Reference`や  
 `ActiveSupport::Dependencies::Blamable`などの補助的なクラスやモジュールも削除されました。
 


### PR DESCRIPTION
電子書籍で `upgrading_ruby_on_rails` の一部分が出力されないバグがあり、対象のコメント部分を削除すると正常に書き出し可能なため、削除しました🙏

- ビルドを確認して修正されていた場合
  - merge 対応します🙏
- 修正されていなかった場合
  - mergeせずクローズします🙇‍♀