### PR TITLE
`to_model`の例から`to_key`と`to_param`の間違った実行例を削除

### DIFF
--- a/guides/source/ja/active_model_basics.md
+++ b/guides/source/ja/active_model_basics.md
@@ -568,10 +568,6 @@ end
 irb> person = Person.new(1)
 irb> person.to_model == person
 => true
-irb> person.to_key
-=> nil
-irb> person.to_param
-=> nil
 ```
 
 自作のモデルがActive Modelオブジェクトらしく振る舞わない場合は、`:to_model`を自分で定義する必要があります。この場合`:to_model`は、Active Modelに準拠したメソッドでオブジェクトをラップするプロキシオブジェクトを返さなければなりません。


### PR DESCRIPTION
このサンプルコードを実行すると、`to_key` は `[1]` に、`to_param` は `"1"` になります。
原文では `to_key` 以下は削除されているようなので、原文に合わせて削除しました。