### PR TITLE
Update active_record_validations.md

### DIFF
--- a/guides/source/ja/active_record_validations.md
+++ b/guides/source/ja/active_record_validations.md
@@ -1220,7 +1220,7 @@ irb> person.valid?
 => false
 
 irb> person.errors.where(:name, :too_short, minimum: 3)
-=> [ ... ] # 最小が2で短すぎるすべてのnameのエラー
+=> [ ... ] # 最小が3で短すぎるすべてのnameのエラー
 ```
 
 これらのエラーオブジェクトから、さまざまな情報を読み出せます。


### PR DESCRIPTION
typo修正です。原著の対応部分は以下。

[Active Record Validations — Ruby on Rails Guides](https://guides.rubyonrails.org/v7.2/active_record_validations.html#errors-where-and-error-object)

```
irb> person.errors.where(:name, :too_short, minimum: 3)
=> [ ... ] # all name errors being too short and minimum is 3
```