### PR TITLE
Update active_support_core_extensions.md

### DIFF
--- a/guides/source/ja/active_support_core_extensions.md
+++ b/guides/source/ja/active_support_core_extensions.md
@@ -38,7 +38,7 @@ require 'active_support'
 
 本ガイドでは、コア拡張機能として定義されているすべてのメソッドについて、その定義ファイルの置き場所も示してあります。たとえば`with_indifferent_access` の場合、以下のようなメモを追加してあります。
 
-NOTE: 定義は[`active_support/core_ext/hash/indifferent_access.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/hash_with_indifferent_access.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/indifferent_access.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/hash_with_indifferent_access.rb)にあります。
 
 つまり、以下のようにピンポイントで`require`を実行できます。
 
@@ -125,7 +125,7 @@ def set_conditional_cache_control!
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/object/blank.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/blank.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/blank.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/blank.rb)にあります。
 
 [Object#blank?]: https://api.rubyonrails.org/classes/Object.html#method-i-blank-3F
 [Object#present?]: https://api.rubyonrails.org/classes/Object.html#method-i-present-3F
@@ -138,7 +138,7 @@ NOTE: 定義は[`active_support/core_ext/object/blank.rb`](https://github.com/ra
 host = config[:host].presence || "localhost"
 ```
 
-NOTE: 定義は[`active_support/core_ext/object/blank.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/blank.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/blank.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/blank.rb)にあります。
 
 [Object#presence]: https://api.rubyonrails.org/classes/Object.html#method-i-presence
 
@@ -166,7 +166,7 @@ Complex(1).duplicable?      # => true
 
 WARNING: どんなクラスでも、`dup`メソッドと`clone`メソッドを除去することでこれらのメソッドを無効にできます。このとき、これらのメソッドが実行されると例外が発生します。このような状態では、どんなオブジェクトについてもそれが複製可能かどうかを確認するには`rescue`を使う以外に方法はありません。`duplicable?`メソッドは、上のハードコードされたリストに依存しますが、その代わり`rescue`よりずっと高速です。実際のユースケースでハードコードされたリストで十分であることがわかっている場合にのみ、`duplicable?`をお使いください。
 
-NOTE: 定義は[`active_support/core_ext/object/duplicable.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/duplicable.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/duplicable.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/duplicable.rb)にあります。
 
 [Object#duplicable?]: https://api.rubyonrails.org/classes/Object.html#method-i-duplicable-3F
 
@@ -213,7 +213,7 @@ duplicate = number.deep_dup
 number.object_id == duplicate.object_id   # => true
 ```
 
-NOTE: 定義は[`active_support/core_ext/object/deep_dup.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/deep_dup.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/deep_dup.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/deep_dup.rb)にあります。
 
 [Object#deep_dup]: https://api.rubyonrails.org/classes/Object.html#method-i-deep_dup
 
@@ -257,7 +257,7 @@ end
 @number.try!(:nest) # NoMethodError: undefined method `nest' for 1:Integer
 ```
 
-NOTE: 定義は[`active_support/core_ext/object/try.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/try.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/try.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/try.rb)にあります。
 
 [Object#try]: https://api.rubyonrails.org/classes/Object.html#method-i-try
 [Object#try!]: https://api.rubyonrails.org/classes/Object.html#method-i-try-21
@@ -281,7 +281,7 @@ class Proc
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/kernel/singleton_class.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/kernel/singleton_class.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/kernel/singleton_class.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/kernel/singleton_class.rb)にあります。
 
 [Kernel#class_eval]: https://api.rubyonrails.org/classes/Kernel.html#method-i-class_eval
 
@@ -302,7 +302,7 @@ some_klass.acts_like?(:string)
 
 Railsには`Date`クラスや`Time`クラスと同様に振る舞うクラスがいくつかあり、この手法を使えます。
 
-NOTE: 定義は[`active_support/core_ext/object/acts_like.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/acts_like.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/acts_like.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/acts_like.rb)にあります。
 
 [Object#acts_like?]: https://api.rubyonrails.org/classes/Object.html#method-i-acts_like-3F
 
@@ -348,7 +348,7 @@ user_path(@user) # => "/users/357-john-smith"
 
 WARNING: コントローラ側では、`to_param`メソッドがモデル側で再定義されている可能性があることに常に注意しておく必要があります。上のようなリクエストを受信した場合、`params[:id]`の値が「357-john-smith」になるからです。
 
-NOTE: 定義は[`active_support/core_ext/object/to_param.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/to_param.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/to_param.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/to_param.rb)にあります。
 
 [Array#to_param]: https://api.rubyonrails.org/classes/Array.html#method-i-to_param
 [Object#to_param]: https://api.rubyonrails.org/classes/Object.html#method-i-to_param
@@ -400,7 +400,7 @@ account.to_query("company[name]")
 # => "user%5Bid%5D=89&user%5Bname%5D=John+Smith"
 ```
 
-NOTE: 定義は[`active_support/core_ext/object/to_query.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/to_query.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/to_query.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/to_query.rb)にあります。
 
 [Hash#to_query]: https://api.rubyonrails.org/classes/Hash.html#method-i-to_query
 [Object#to_query]: https://api.rubyonrails.org/classes/Object.html#method-i-to_query
@@ -444,7 +444,7 @@ end
 
 TIP: `with_options`はメソッドをレシーバに転送しているので、呼び出しをネストすることもできます。各ネスティングレベルでは、自身の呼び出しに、継承したデフォルト呼び出しをマージします。
 
-NOTE: 定義は[`active_support/core_ext/object/with_options.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/with_options.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/with_options.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/with_options.rb)にあります。
 
 [Object#with_options]: https://api.rubyonrails.org/classes/Object.html#method-i-with_options
 
@@ -452,7 +452,7 @@ NOTE: 定義は[`active_support/core_ext/object/with_options.rb`](https://github
 
 Active Supportが提供する`to_json`メソッドの実装は、通常`json` gemがRubyオブジェクトに対して提供している`to_json`よりも優れています。その理由は、`Hash`や`OrderedHash`、`Process::Status`などのクラスでは、正しいJSON表現を提供するために特別な処理が必要になるためです。
 
-NOTE: 定義は[`active_support/core_ext/object/json.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/json.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/json.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/json.rb)にあります。
 
 ### インスタンス変数
 
@@ -472,7 +472,7 @@ end
 C.new(0, 1).instance_values # => {"x" => 0, "y" => 1}
 ```
 
-NOTE: 定義は[`active_support/core_ext/object/instance_variables.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/instance_variables.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/instance_variables.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/instance_variables.rb)にあります。
 
 [Object#instance_values]: https://api.rubyonrails.org/classes/Object.html#method-i-instance_values
 
@@ -490,7 +490,7 @@ end
 C.new(0, 1).instance_variable_names # => ["@x", "@y"]
 ```
 
-NOTE: 定義は[`active_support/core_ext/object/instance_variables.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/instance_variables.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/instance_variables.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/instance_variables.rb)にあります。
 
 [Object#instance_variable_names]: https://api.rubyonrails.org/classes/Object.html#method-i-instance_variable_names
 
@@ -511,7 +511,7 @@ suppress(ActiveRecord::StaleObjectError) do
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/kernel/reporting.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/kernel/reporting.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/kernel/reporting.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/kernel/reporting.rb)にあります。
 
 [Kernel#enable_warnings]: https://api.rubyonrails.org/classes/Kernel.html#method-i-enable_warnings
 [Kernel#silence_warnings]: https://api.rubyonrails.org/classes/Kernel.html#method-i-silence_warnings
@@ -530,7 +530,7 @@ NOTE: 定義は[`active_support/core_ext/kernel/reporting.rb`](https://github.co
 1.in?(1)             # => ArgumentError
 ```
 
-NOTE: 定義は[`active_support/core_ext/object/inclusion.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/inclusion.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/inclusion.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/inclusion.rb)にあります。
 
 [Object#in?]: https://api.rubyonrails.org/classes/Object.html#method-i-in-3F
 
@@ -551,7 +551,7 @@ class User < ApplicationRecord
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/module/aliasing.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/module/aliasing.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/module/aliasing.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/module/aliasing.rb)にあります。
 
 [Module#alias_attribute]: https://api.rubyonrails.org/classes/Module.html#method-i-alias_attribute
 
@@ -591,7 +591,7 @@ module ActionView
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/module/attr_internal.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/module/attr_internal.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/module/attr_internal.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/module/attr_internal.rb)にあります。
 
 [Module#attr_internal]: https://api.rubyonrails.org/classes/Module.html#method-i-attr_internal
 [Module#attr_internal_accessor]: https://api.rubyonrails.org/classes/Module.html#method-i-attr_internal_accessor
@@ -610,7 +610,7 @@ module ActiveStorage
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/module/attribute_accessors.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/module/attribute_accessors.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/module/attribute_accessors.rb)にあります。
 
 [Module#mattr_accessor]: https://api.rubyonrails.org/classes/Module.html#method-i-mattr_accessor
 [Module#mattr_reader]: https://api.rubyonrails.org/classes/Module.html#method-i-mattr_reader
@@ -639,7 +639,7 @@ M.module_parent       # => X::Y
 
 WARNING: `module_parent_name`はこの場合に`nil`を返します。
 
-NOTE: 定義は[`active_support/core_ext/module/introspection.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/module/introspection.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/module/introspection.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/module/introspection.rb)にあります。
 
 [Module#module_parent]: https://api.rubyonrails.org/classes/Module.html#method-i-module_parent
 
@@ -664,7 +664,7 @@ M.module_parent_name       # => "X::Y"
 
 WARNING: `module_parent`はこの場合`Object`を返します。
 
-NOTE: 定義は[`active_support/core_ext/module/introspection.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/module/introspection.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/module/introspection.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/module/introspection.rb)にあります。
 
 [Module#module_parent_name]: https://api.rubyonrails.org/classes/Module.html#method-i-module_parent_name
 
@@ -685,7 +685,7 @@ X::Y::Z.module_parents # => [X::Y, X, Object]
 M.module_parents       # => [X::Y, X, Object]
 ```
 
-NOTE: 定義は[`active_support/core_ext/module/introspection.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/module/introspection.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/module/introspection.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/module/introspection.rb)にあります。
 
 [Module#module_parents]: https://api.rubyonrails.org/classes/Module.html#method-i-module_parents
 
@@ -727,7 +727,7 @@ m.anonymous? # => false
 
 逆に無名モジュールは、定義上必ず到達不能になります。
 
-NOTE: 定義は[`active_support/core_ext/module/anonymous.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/module/anonymous.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/module/anonymous.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/module/anonymous.rb)にあります。
 
 [Module#anonymous?]: https://api.rubyonrails.org/classes/Module.html#method-i-anonymous-3F
 
@@ -823,7 +823,7 @@ delegate :date_of_birth, to: :profile, private: true
 
 委譲されたメソッドはデフォルトでpublicになりますが、`private: true`を渡すことで変更できます。
 
-NOTE: 定義は[`active_support/core_ext/module/delegation.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/module/delegation.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/module/delegation.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/module/delegation.rb)にあります。
 
 [Module#delegate]: https://api.rubyonrails.org/classes/Module.html#method-i-delegate
 
@@ -841,7 +841,7 @@ end
 
 オブジェクト内にある呼び出し可能なもの（インスタンス変数、メソッド、定数など）なら何でも対象にできます。対象のうち、publicなメソッドだけが委譲されます。
 
-NOTE: 定義は[`active_support/core_ext/module/delegation.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/module/delegation.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/module/delegation.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/module/delegation.rb)にあります。
 
 [Module#delegate_missing_to]: https://api.rubyonrails.org/classes/Module.html#method-i-delegate_missing_to
 
@@ -853,7 +853,7 @@ NOTE: 定義は[`active_support/core_ext/module/delegation.rb`](https://github.c
 
 （`delegate`を使っているなどの理由で）メソッド自身の置き換えを定義する必要がある場合は、[`silence_redefinition_of_method`][Module#silence_redefinition_of_method]を使うこともできます。
 
-NOTE: 定義は[`active_support/core_ext/module/redefine_method.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/module/redefine_method.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/module/redefine_method.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/module/redefine_method.rb)にあります。
 
 [Module#redefine_method]: https://api.rubyonrails.org/classes/Module.html#method-i-redefine_method
 [Module#silence_redefinition_of_method]: https://api.rubyonrails.org/classes/Module.html#method-i-silence_redefinition_of_method
@@ -943,7 +943,7 @@ A.new.x # NoMethodError
 
 インスタンス述語が不要な場合、`instance_predicate: false`を指定すれば定義されなくなります。
 
-NOTE: 定義は[`active_support/core_ext/class/attribute.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/class/attribute.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/class/attribute.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/class/attribute.rb)にあります。
 
 [Class#class_attribute]: https://api.rubyonrails.org/classes/Class.html#method-i-class_attribute
 
@@ -998,7 +998,7 @@ end
 
 `:instance_accessor`を`false`に設定すると、モデルの属性設定時にマスアサインメントを防止するのに便利です。
 
-NOTE: 定義は[`active_support/core_ext/module/attribute_accessors.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/class/attribute_accessors.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/module/attribute_accessors.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/class/attribute_accessors.rb)にあります。
 
 [Module#cattr_accessor]: https://api.rubyonrails.org/classes/Module.html#method-i-cattr_accessor
 [Module#cattr_reader]: https://api.rubyonrails.org/classes/Module.html#method-i-cattr_reader
@@ -1026,7 +1026,7 @@ C.subclasses # => [B, D]
 
 返されるクラスの順序は一定ではありません。
 
-NOTE: 定義は[`active_support/core_ext/class/subclasses.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/class/subclasses.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/class/subclasses.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/class/subclasses.rb)にあります。
 
 [Class#subclasses]: https://api.rubyonrails.org/classes/Class.html#method-i-subclasses
 
@@ -1050,7 +1050,7 @@ C.descendants # => [B, A, D]
 
 返されるクラスの順序は一定ではありません。
 
-NOTE: 定義は[`active_support/core_ext/class/subclasses.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/class/subclasses.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/class/subclasses.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/class/subclasses.rb)にあります。
 
 [Class#descendants]: https://api.rubyonrails.org/classes/Class.html#method-i-descendants
 
@@ -1128,7 +1128,7 @@ def raw(stringish)
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/output_safety.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/output_safety.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/output_safety.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/output_safety.rb)にあります。
 
 [`raw`]: https://api.rubyonrails.org/classes/ActionView/Helpers/OutputSafetyHelper.html#method-i-raw
 [String#html_safe]: https://api.rubyonrails.org/classes/String.html#method-i-html_safe
@@ -1159,7 +1159,7 @@ INFO: こうしたメソッドを実行すると、実際に変換が行われ�
 
 このメソッドには破壊的なバージョンの`String#remove!`もあります。
 
-NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/filters.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/filters.rb)にあります。
 
 [String#remove]: https://api.rubyonrails.org/classes/String.html#method-i-remove
 
@@ -1175,7 +1175,7 @@ NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/
 
 このメソッドでは、ASCIIとUnicodeのホワイトスペースを扱えます。
 
-NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/filters.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/filters.rb)にあります。
 
 [String#squish]: https://api.rubyonrails.org/classes/String.html#method-i-squish
 
@@ -1215,7 +1215,7 @@ NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/
 
 上の例では、"dear"という単語の途中で切り落とされそうになるところを、`:separator`によって防いでいます。
 
-NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/filters.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/filters.rb)にあります。
 
 [String#truncate]: https://api.rubyonrails.org/classes/String.html#method-i-truncate
 
@@ -1236,7 +1236,7 @@ NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/
 # => "👍👍🖖"
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/filters.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/filters.rb)にあります。
 
 [String#truncate_bytes]: https://api.rubyonrails.org/classes/String.html#method-i-truncate_bytes
 
@@ -1270,7 +1270,7 @@ NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/
 # => "Oh dear! Oh dear!..."
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/filters.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/filters.rb)にあります。
 
 [String#truncate_words]: https://api.rubyonrails.org/classes/String.html#method-i-truncate_word
 
@@ -1283,7 +1283,7 @@ NOTE: 定義は[`active_support/core_ext/string/filters.rb`](https://github.com/
 "active".inquiry.inactive?       # => false
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/inquiry.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inquiry.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inquiry.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inquiry.rb)にあります。
 
 [String#inquiry]: https://api.rubyonrails.org/classes/String.html#method-i-inquiry
 
@@ -1296,7 +1296,7 @@ Active Supportでは、`String#start_with?`と`String#end_with?`を英語的に�
 "foo".ends_with?("o")   # => true
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/starts_ends_with.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/starts_ends_with.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/starts_ends_with.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/starts_ends_with.rb)にあります。
 
 ### `strip_heredoc`
 
@@ -1320,7 +1320,7 @@ end
 
 技術的には、インデントが最も浅い行を探して、そのインデント分だけ行頭のホワイトスペースを全体から削除するという操作を行っています。
 
-NOTE: 定義は[`active_support/core_ext/string/strip.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/strip.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/strip.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/strip.rb)にあります。
 
 [String#strip_heredoc]: https://api.rubyonrails.org/classes/String.html#method-i-strip_heredoc
 
@@ -1359,7 +1359,7 @@ EOS
 
 [`indent!`][String#indent!]メソッドはインデントをその場で (破壊的に) 行います。
 
-NOTE: 定義は[`active_support/core_ext/string/indent.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/indent.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/indent.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/indent.rb)にあります。
 
 [String#indent!]: https://api.rubyonrails.org/classes/String.html#method-i-indent-21
 [String#indent]: https://api.rubyonrails.org/classes/String.html#method-i-indent
@@ -1377,7 +1377,7 @@ NOTE: 定義は[`active_support/core_ext/string/indent.rb`](https://github.com/r
 "hello".at(10) # => nil
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/access.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/access.rb)にあります。
 
 [String#at]: https://api.rubyonrails.org/classes/String.html#method-i-at
 
@@ -1392,7 +1392,7 @@ NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/r
 "hello".from(10) # => nil
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/access.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/access.rb)にあります。
 
 [String#from]: https://api.rubyonrails.org/classes/String.html#method-i-from
 
@@ -1407,7 +1407,7 @@ NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/r
 "hello".to(10) # => "hello"
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/access.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/access.rb)にあります。
 
 [String#to]: https://api.rubyonrails.org/classes/String.html#method-i-to
 
@@ -1417,7 +1417,7 @@ NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/r
 
 `str.first(n)`という呼び出しは、`n` > 0の場合は`str.to(n-1)`と等価です。`n` == 0の場合は空文字列を返します。
 
-NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/access.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/access.rb)にあります。
 
 [String#first]: https://api.rubyonrails.org/classes/String.html#method-i-first
 
@@ -1427,7 +1427,7 @@ NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/r
 
 `str.last(n)` という呼び出しは、`n` > 0の場合は`str.from(-n)`と等価です。`n` == 0の場合は空文字列を返します。
 
-NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/access.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/access.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/access.rb)にあります。
 
 [String#last]: https://api.rubyonrails.org/classes/String.html#method-i-last
 
@@ -1463,7 +1463,7 @@ def undecorated_table_name(model_name)
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#pluralize]: https://api.rubyonrails.org/classes/String.html#method-i-pluralize
 
@@ -1488,7 +1488,7 @@ def derive_class_name
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#singularize]: https://api.rubyonrails.org/classes/String.html#method-i-singularize
 
@@ -1538,7 +1538,7 @@ end
 
 [`camelcase`][String#camelcase]は`camelize`のエイリアスです。
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#camelcase]: https://api.rubyonrails.org/classes/String.html#method-i-camelcase
 [String#camelize]: https://api.rubyonrails.org/classes/String.html#method-i-camelize
@@ -1580,7 +1580,7 @@ end
 
 INFO: `underscore`メソッドの動作は、`camelize`メソッドと逆の動作と考えるとわかりやすいでしょう。ただし完全に逆の動作ではありません。たとえば、`"SSLError".underscore.camelize`を実行した結果は`"SslError"`になり、元に戻りません。
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#underscore]: https://api.rubyonrails.org/classes/String.html#method-i-underscore
 
@@ -1595,7 +1595,7 @@ NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.
 
 [`titlecase`][String#titlecase]メソッドは`titleize`のエイリアスです。
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#titlecase]: https://api.rubyonrails.org/classes/String.html#method-i-titlecase
 [String#titleize]: https://api.rubyonrails.org/classes/String.html#method-i-titleize
@@ -1619,7 +1619,7 @@ def reformat_name(name)
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#dasherize]: https://api.rubyonrails.org/classes/String.html#method-i-dasherize
 
@@ -1649,7 +1649,7 @@ def counter_cache_column
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#demodulize]: https://api.rubyonrails.org/classes/String.html#method-i-demodulize
 
@@ -1663,7 +1663,7 @@ NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.
 "Admin::Hotel::ReservationUtils".deconstantize # => "Admin::Hotel"
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#deconstantize]: https://api.rubyonrails.org/classes/String.html#method-i-deconstantize
 
@@ -1690,7 +1690,7 @@ NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.
 "Kurt Gödel".parameterize(separator: "_") # => "kurt_godel"
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#parameterize]: https://api.rubyonrails.org/classes/String.html#method-i-parameterize
 
@@ -1706,7 +1706,7 @@ NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.
 
 単純な場合であれば、モデル名に`tableize`を使うとモデルのテーブル名を得られます。実際のActive Recordの実装は、単に`tableize`を実行する場合よりも複雑です。Active Recordではクラス名に対して`demodulize`も行っており、返される文字列に影響する可能性のあるオプションもいくつかチェックしています。
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#tableize]: https://api.rubyonrails.org/classes/String.html#method-i-tableize
 
@@ -1728,7 +1728,7 @@ NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.
 
 `classify`が返すクラス名は文字列であることにご注意ください。得られた文字列に対して`constantize` (後述) を実行することで実際のクラスオブジェクトを得られます。
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#classify]: https://api.rubyonrails.org/classes/String.html#method-i-classify
 
@@ -1773,7 +1773,7 @@ rescue NameError => e
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#constantize]: https://api.rubyonrails.org/classes/String.html#method-i-constantize
 
@@ -1822,7 +1822,7 @@ def full_message
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#humanize]: https://api.rubyonrails.org/classes/String.html#method-i-humanize
 
@@ -1849,7 +1849,7 @@ NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.
 foreign_key = options[:foreign_key] || reflection.active_record.name.foreign_key
 ```
 
-NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/inflections.rb)にあります。
 
 [String#foreign_key]: https://api.rubyonrails.org/classes/String.html#method-i-foreign_key
 
@@ -1904,7 +1904,7 @@ NOTE: Defined in `active_support/core_ext/string/inflections.rb`.
 
 INFO: 3つのメソッドはいずれも、レシーバが空の場合は`nil`を返します。
 
-NOTE: 定義は[`active_support/core_ext/string/conversions.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/string/conversions.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/string/conversions.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/string/conversions.rb)にあります。
 
 [String#to_date]: https://api.rubyonrails.org/classes/String.html#method-i-to_date
 [String#to_datetime]: https://api.rubyonrails.org/classes/String.html#method-i-to_datetime
@@ -1941,7 +1941,7 @@ NOTE: 定義は[`active_support/core_ext/string/conversions.rb`](https://github.
 1.megabyte # => 1048576
 ```
 
-NOTE: 定義は[`active_support/core_ext/numeric/bytes.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/numeric/bytes.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/numeric/bytes.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/numeric/bytes.rb)にあります。
 
 [Numeric#bytes]: https://api.rubyonrails.org/classes/Numeric.html#method-i-bytes
 [Numeric#exabytes]: https://api.rubyonrails.org/classes/Numeric.html#method-i-exabytes
@@ -1981,7 +1981,7 @@ NOTE: 定義は[`active_support/core_ext/numeric/bytes.rb`](https://github.com/r
 
 WARNING: 上記以外の期間については、`Integer`の`Time`拡張を参照してください。
 
-NOTE: 定義は[`active_support/core_ext/numeric/time.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/numeric/time.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/numeric/time.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/numeric/time.rb)にあります。
 
 [Duration#ago]: https://api.rubyonrails.org/classes/ActiveSupport/Duration.html#method-i-ago
 [Duration#from_now]: https://api.rubyonrails.org/classes/ActiveSupport/Duration.html#method-i-from_now
@@ -2080,7 +2080,7 @@ NOTE: 定義は[`active_support/core_ext/numeric/time.rb`](https://github.com/ra
 1234567890123456.to_fs(:human)  # => "1.23 Quadrillion"
 ```
 
-NOTE: 定義は[`active_support/core_ext/numeric/conversions.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/numeric/conversions.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/numeric/conversions.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/numeric/conversions.rb)にあります。
 
 `Integer`の拡張
 -----------------------
@@ -2094,7 +2094,7 @@ NOTE: 定義は[`active_support/core_ext/numeric/conversions.rb`](https://github
 1.multiple_of?(2) # => false
 ```
 
-NOTE: 定義は[`active_support/core_ext/integer/multiple.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/integer/multiple.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/integer/multiple.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/integer/multiple.rb)にあります。
 
 [Integer#multiple_of?]: https://api.rubyonrails.org/classes/Integer.html#method-i-multiple_of-3F
 
@@ -2111,7 +2111,7 @@ NOTE: 定義は[`active_support/core_ext/integer/multiple.rb`](https://github.co
 -134.ordinal # => "th"
 ```
 
-NOTE: 定義は[`active_support/core_ext/integer/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/integer/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/integer/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/integer/inflections.rb)にあります。
 
 [Integer#ordinal]: https://api.rubyonrails.org/classes/Integer.html#method-i-ordinal
 
@@ -2128,7 +2128,7 @@ NOTE: 定義は[`active_support/core_ext/integer/inflections.rb`](https://github
 -134.ordinalize # => "-134th"
 ```
 
-NOTE: 定義は[`active_support/core_ext/integer/inflections.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/integer/inflections.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/integer/inflections.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/integer/inflections.rb)にあります。
 
 [Integer#ordinalize]: https://api.rubyonrails.org/classes/Integer.html#method-i-ordinalize
 
@@ -2156,7 +2156,7 @@ NOTE: 定義は[`active_support/core_ext/integer/inflections.rb`](https://github
 
 WARNING: 上記以外の期間については、`Numeric`の`Time`拡張を参照してください。
 
-NOTE: 定義は[`active_support/core_ext/integer/time.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/integer/time.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/integer/time.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/integer/time.rb)にあります。
 
 [Integer#months]: https://api.rubyonrails.org/classes/Integer.html#method-i-months
 [Integer#years]: https://api.rubyonrails.org/classes/Integer.html#method-i-years
@@ -2194,7 +2194,7 @@ invoices.index_by(&:number)
 
 WARNING: キーは通常は一意でなければなりません。異なる要素から同じ値が返されると、そのキーのコレクションは作成されません。返された項目のうち、最後の項目だけが使われます。
 
-NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
 
 [Enumerable#index_by]: https://api.rubyonrails.org/classes/Enumerable.html#method-i-index_by
 
@@ -2212,7 +2212,7 @@ WEEKDAYS.index_with(Interval.all_day)
 # => { monday: [ 0, 1440 ], … }
 ```
 
-NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
 
 
 [Enumerable#index_with]: https://api.rubyonrails.org/classes/Enumerable.html#method-i-index_with
@@ -2233,7 +2233,7 @@ NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rail
 @see_more = videos.many? { |video| video.category == params[:category] }
 ```
 
-NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
 
 [Enumerable#many?]: https://api.rubyonrails.org/classes/Enumerable.html#method-i-many-3F
 
@@ -2245,7 +2245,7 @@ NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rail
 to_visit << node if visited.exclude?(node)
 ```
 
-NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
 
 [Enumerable#exclude?]: https://api.rubyonrails.org/classes/Enumerable.html#method-i-exclude-3F
 
@@ -2259,7 +2259,7 @@ NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rail
 ["David", "Rafael"].including %w[ Aaron Todd ] # => ["David", "Rafael", "Aaron", "Todd"]
 ```
 
-NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
 
 [Enumerable#including]: https://api.rubyonrails.org/classes/Enumerable.html#method-i-including
 
@@ -2274,7 +2274,7 @@ NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rail
 
 [`without`][Enumerable#without]は`excluding`のエイリアスです。
 
-NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
 
 [Enumerable#excluding]: https://api.rubyonrails.org/classes/Enumerable.html#method-i-excluding
 [Enumerable#without]: https://api.rubyonrails.org/classes/Enumerable.html#method-i-without
@@ -2287,7 +2287,7 @@ NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rail
 [{ name: "David" }, { name: "Rafael" }, { name: "Aaron" }].pluck(:name) # => ["David", "Rafael", "Aaron"]
 ```
 
-NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
 
 [Enumerable#pluck]: https://api.rubyonrails.org/classes/Enumerable.html#method-i-pluck
 
@@ -2300,7 +2300,7 @@ NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rail
 [{ id: 1, name: "David" }, { id: 2, name: "Rafael" }].pick(:id, :name) # => [1, "David"]
 ```
 
-NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/enumerable.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/enumerable.rb)にあります。
 
 [Enumerable#pick]: https://api.rubyonrails.org/classes/Enumerable.html#method-i-pick
 
@@ -2346,7 +2346,7 @@ Active Supportには配列のAPIが多数追加されており、配列に容易
 %w(a b c d).fifth # => nil
 ```
 
-NOTE: 定義は[`active_support/core_ext/array/access.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/array/access.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/array/access.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/array/access.rb)にあります。
 
 [Array#excluding]: https://api.rubyonrails.org/classes/Array.html#method-i-excluding
 [Array#fifth]: https://api.rubyonrails.org/classes/Array.html#method-i-fifth
@@ -2370,7 +2370,7 @@ odd_numbers = numbers.extract! { |number| number.odd? } # => [1, 3, 5, 7, 9]
 numbers # => [0, 2, 4, 6, 8]
 ```
 
-NOTE: 定義は[`active_support/core_ext/array/extract.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/array/extract.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/array/extract.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/array/extract.rb)にあります。
 
 [Array#extract!]: https://api.rubyonrails.org/classes/Array.html#method-i-extract-21
 
@@ -2400,7 +2400,7 @@ end
 
 このメソッドは、任意の数のアクション名を引数に取ることができ、引数の末尾項目でオプションハッシュを使えます。`extract_options!`メソッドを使うと、このオプションハッシュの取得と`actions`からの除去を簡単かつ明示的に行えます。
 
-NOTE: 定義は[`active_support/core_ext/array/extract_options.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/array/extract_options.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/array/extract_options.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/array/extract_options.rb)にあります。
 
 [Array#extract_options!]: https://api.rubyonrails.org/classes/Array.html#method-i-extract_options-21
 
@@ -2431,7 +2431,7 @@ NOTE: 定義は[`active_support/core_ext/array/extract_options.rb`](https://gith
 | `:words_connector`     | `support.array.words_connector`     |
 | `:last_word_connector` | `support.array.last_word_connector` |
 
-NOTE: 定義は[`active_support/core_ext/array/conversions.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/array/conversions.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/array/conversions.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/array/conversions.rb)にあります。
 
 [Array#to_sentence]: https://api.rubyonrails.org/classes/Array.html#method-i-to_sentence
 
@@ -2449,7 +2449,7 @@ invoice.lines.to_fs(:db) # => "23,567,556,12"
 
 上の例の整数は、`id`への呼び出しによって取り出されたものとみなされます。
 
-NOTE: 定義は[`active_support/core_ext/array/conversions.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/array/conversions.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/array/conversions.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/array/conversions.rb)にあります。
 
 [Array#to_fs]: https://api.rubyonrails.org/classes/Array.html#method-i-to_fs
 
@@ -2552,7 +2552,7 @@ Contributor.limit(2).order(:rank).to_xml(skip_types: true)
 # </contributors>
 ```
 
-NOTE: 定義は[`active_support/core_ext/array/conversions.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/array/conversions.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/array/conversions.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/array/conversions.rb)にあります。
 
 [Array#to_xml]: https://api.rubyonrails.org/classes/Array.html#method-i-to_xml
 
@@ -2591,7 +2591,7 @@ Array(foo: :bar)      # => [[:foo, :bar]]
 [*object]
 ```
 
-NOTE: 定義は[`active_support/core_ext/array/wrap.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/array/wrap.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/array/wrap.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/array/wrap.rb)にあります。
 
 [Array.wrap]: https://api.rubyonrails.org/classes/Array.html#method-c-wrap
 
@@ -2606,7 +2606,7 @@ dup[1][2] = 4
 array[1][2] == nil   # => true
 ```
 
-NOTE: 定義は[`active_support/core_ext/object/deep_dup.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/deep_dup.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/deep_dup.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/deep_dup.rb)にあります。
 
 [Array#deep_dup]: https://api.rubyonrails.org/classes/Array.html#method-i-deep_dup
 
@@ -2646,7 +2646,7 @@ NOTE: 定義は[`active_support/core_ext/object/deep_dup.rb`](https://github.com
 
 このため、`false`は空きを埋める値としては利用できません。
 
-NOTE: 定義は[`active_support/core_ext/array/grouping.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/array/grouping.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/array/grouping.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/array/grouping.rb)にあります。
 
 [Array#in_groups_of]: https://api.rubyonrails.org/classes/Array.html#method-i-in_groups_of
 
@@ -2686,7 +2686,7 @@ NOTE: 定義は[`active_support/core_ext/array/grouping.rb`](https://github.com/
 
 このため、`false`は空きを埋める値としては利用できません。
 
-NOTE: 定義は[`active_support/core_ext/array/grouping.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/array/grouping.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/array/grouping.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/array/grouping.rb)にあります。
 
 [Array#in_groups]: https://api.rubyonrails.org/classes/Array.html#method-i-in_groups
 
@@ -2710,7 +2710,7 @@ NOTE: 定義は[`active_support/core_ext/array/grouping.rb`](https://github.com/
 
 TIP: 上の例からもわかるように、セパレータが連続すると空の配列になります。
 
-NOTE: 定義は[`active_support/core_ext/array/grouping.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/array/grouping.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/array/grouping.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/array/grouping.rb)にあります。
 
 [Array#split]: https://api.rubyonrails.org/classes/Array.html#method-i-split
 
@@ -2763,7 +2763,7 @@ rootノードはデフォルトでは「hash」ですが、`:root`オプショ�
 
 デフォルトのXMLビルダは、`Builder::XmlMarkup`から直接生成されたインスタンスです。`:builder`オブションで独自のビルダを構成できます。このメソッドでは`:dasherize`とその同族と同様のオプションが利用でき、指定したオプションはビルダに転送されます。
 
-NOTE: 定義は[`active_support/core_ext/hash/conversions.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/hash/conversions.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/conversions.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/hash/conversions.rb)にあります。
 
 [Hash#to_xml]: https://api.rubyonrails.org/classes/Hash.html#method-i-to_xml
 
@@ -2800,7 +2800,7 @@ options.reverse_merge!(length: 30, omission: "...")
 
 WARNING: `reverse_merge!`は呼び出し元のハッシュを変更する可能性があることにご注意ください。それが意図した副作用であるかそうでないかにかかわらず、注意が必要です。
 
-NOTE: 定義は[`active_support/core_ext/hash/reverse_merge.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/reverse_merge.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb)にあります。
 
 [Hash#reverse_merge!]: https://api.rubyonrails.org/classes/Hash.html#method-i-reverse_merge-21
 [Hash#reverse_merge]: https://api.rubyonrails.org/classes/Hash.html#method-i-reverse_merge
@@ -2811,7 +2811,7 @@ NOTE: 定義は[`active_support/core_ext/hash/reverse_merge.rb`](https://github.
 
 WARNING: `reverse_update`には`!`のついたバージョンはありません。
 
-NOTE: 定義は[`active_support/core_ext/hash/reverse_merge.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/reverse_merge.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/hash/reverse_merge.rb)にあります。
 
 [Hash#reverse_update]: https://api.rubyonrails.org/classes/Hash.html#method-i-reverse_update
 
@@ -2828,7 +2828,7 @@ Active Supportでは[`Hash#deep_merge`][Hash#deep_merge]が定義されていま
 
 [`deep_merge!`][Hash#deep_merge!]メソッドはディープマージを破壊的に実行します。
 
-NOTE: 定義は[`active_support/core_ext/hash/deep_merge.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/hash/deep_merge.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/deep_merge.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/hash/deep_merge.rb)にあります。
 
 [Hash#deep_merge!]: https://api.rubyonrails.org/classes/Hash.html#method-i-deep_merge-21
 [Hash#deep_merge]: https://api.rubyonrails.org/classes/Hash.html#method-i-deep_merge
@@ -2848,7 +2848,7 @@ hash[:b][:e] == nil      # => true
 hash[:b][:d] == [3, 4]   # => true
 ```
 
-NOTE: 定義は[`active_support/core_ext/object/deep_dup.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/object/deep_dup.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/object/deep_dup.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/object/deep_dup.rb)にあります。
 
 [Hash#deep_dup]: https://api.rubyonrails.org/classes/Hash.html#method-i-deep_dup
 
@@ -2870,7 +2870,7 @@ NOTE: 定義は[`active_support/core_ext/object/deep_dup.rb`](https://github.com
 { a: 1 }.with_indifferent_access.except!("a") # => {}
 ```
 
-NOTE: 定義は[`active_support/core_ext/hash/except.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/hash/except.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/except.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/hash/except.rb)にあります。
 
 [Hash#except!]: https://api.rubyonrails.org/classes/Hash.html#method-i-except-21
 
@@ -2912,7 +2912,7 @@ end
 # => {""=>nil, "1"=>1, "nested"=>{"a"=>3, "5"=>5}}
 ```
 
-NOTE: 定義は[`active_support/core_ext/hash/keys.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/hash/keys.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/keys.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/hash/keys.rb)にあります。
 
 [Hash#deep_stringify_keys!]: https://api.rubyonrails.org/classes/Hash.html#method-i-deep_stringify_keys-21
 [Hash#deep_stringify_keys]: https://api.rubyonrails.org/classes/Hash.html#method-i-deep_stringify_keys
@@ -2959,7 +2959,7 @@ end
 # => {nil=>nil, 1=>1, nested:{a:3, 5=>5}}
 ```
 
-NOTE: 定義は[`active_support/core_ext/hash/keys.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/hash/keys.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/keys.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/hash/keys.rb)にあります。
 
 [Hash#deep_symbolize_keys!]: https://api.rubyonrails.org/classes/Hash.html#method-i-deep_symbolize_keys-21
 [Hash#deep_symbolize_keys]: https://api.rubyonrails.org/classes/Hash.html#method-i-deep_symbolize_keys
@@ -2970,7 +2970,7 @@ NOTE: 定義は[`active_support/core_ext/hash/keys.rb`](https://github.com/rails
 
 [`to_options`][Hash#to_options]と[`to_options!`][Hash#to_options!]メソッドは、それぞれ`symbolize_keys`メソッドと`symbolize_keys!`メソッドのエイリアスです。
 
-NOTE: 定義は[`active_support/core_ext/hash/keys.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/hash/keys.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/keys.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/hash/keys.rb)にあります。
 
 [Hash#to_options!]: https://api.rubyonrails.org/classes/Hash.html#method-i-to_options-21
 [Hash#to_options]: https://api.rubyonrails.org/classes/Hash.html#method-i-to_options
@@ -2986,7 +2986,7 @@ NOTE: 定義は[`active_support/core_ext/hash/keys.rb`](https://github.com/rails
 
 たとえばActive Recordは、関連付けをビルドするときに未知のオプションを受け付けません。Active Recordは`assert_valid_keys`による制御を実装しています。
 
-NOTE: 定義は[`active_support/core_ext/hash/keys.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/hash/keys.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/keys.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/hash/keys.rb)にあります。
 
 [Hash#assert_valid_keys]: https://api.rubyonrails.org/classes/Hash.html#method-i-assert_valid_keys
 
@@ -3005,7 +3005,7 @@ hash.deep_transform_values { |value| value.to_s.upcase }
 
 ブロック操作を用いてすべての値を破壊的に変更する[`deep_transform_values!`][Hash#deep_transform_values!]もあります。
 
-NOTE: 定義は[`active_support/core_ext/hash/deep_transform_values.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/hash/deep_transform_values.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/deep_transform_values.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/hash/deep_transform_values.rb)にあります。
 
 [Hash#deep_transform_values!]: https://api.rubyonrails.org/classes/Hash.html#method-i-deep_transform_values-21
 [Hash#deep_transform_values]: https://api.rubyonrails.org/classes/Hash.html#method-i-deep_transform_values
@@ -3020,7 +3020,7 @@ rest = hash.slice!(:a) # => {:b=>2}
 hash                   # => {:a=>1}
 ```
 
-NOTE: 定義は[`active_support/core_ext/hash/slice.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/hash/slice.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/slice.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/hash/slice.rb)にあります。
 
 [Hash#slice!]: https://api.rubyonrails.org/classes/Hash.html#method-i-slice-21
 
@@ -3042,7 +3042,7 @@ rest = hash.extract!(:a).class
 # => ActiveSupport::HashWithIndifferentAccess
 ```
 
-NOTE: 定義は[`active_support/core_ext/hash/slice.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/hash/slice.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/slice.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/hash/slice.rb)にあります。
 
 [Hash#extract!]: https://api.rubyonrails.org/classes/Hash.html#method-i-extract-21
 
@@ -3054,7 +3054,7 @@ NOTE: 定義は[`active_support/core_ext/hash/slice.rb`](https://github.com/rail
 {a: 1}.with_indifferent_access["a"] # => 1
 ```
 
-NOTE: 定義は[`active_support/core_ext/hash/indifferent_access.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/hash/indifferent_access.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/hash/indifferent_access.rb)にあります。
 
 [ActiveSupport::HashWithIndifferentAccess]: https://api.rubyonrails.org/classes/ActiveSupport/HashWithIndifferentAccess.html
 [Hash#with_indifferent_access]: https://api.rubyonrails.org/classes/Hash.html#method-i-with_indifferent_access
@@ -3086,7 +3086,7 @@ def verify_regexp_requirements(requirements)
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/regexp.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/regexp.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/regexp.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/regexp.rb)にあります。
 
 [Regexp#multiline?]: https://api.rubyonrails.org/classes/Regexp.html#method-i-multiline-3F
 
@@ -3107,7 +3107,7 @@ Active Supportでは、オプションのフォーマット引数を理解する
 
 上の例でもわかるように、フォーマットに`:db`を指定するとSQLの`BETWEEN`句が生成されます。このフォーマットは、Active Recordで条件の値の範囲をサポートするときに使われます。
 
-NOTE: 定義は[`active_support/core_ext/range/conversions.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/range/conversions.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/range/conversions.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/range/conversions.rb)にあります。
 
 ### `===`、`include?`
 
@@ -3131,7 +3131,7 @@ Active Supportではこれらのメソッドを拡張して、他の範囲指定
 (1...9).include?(3..9)  # => false
 ```
 
-NOTE: 定義は[`active_support/core_ext/range/compare_range.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/range/compare_range.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/range/compare_range.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/range/compare_range.rb)にあります。
 
 ### `overlap?`
 
@@ -3143,7 +3143,7 @@ NOTE: 定義は[`active_support/core_ext/range/compare_range.rb`](https://github
 (1..10).overlap?(11..27) # => false
 ```
 
-NOTE: 定義は[`active_support/core_ext/range/overlap.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/range/overlap.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/range/overlap.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/range/overlap.rb)にあります。
 
 [Range#overlap?]: https://api.rubyonrails.org/classes/Range.html#method-i-overlap-3F
 
@@ -3160,7 +3160,7 @@ Active Supportでは、[`Date.current`][Date.current]を定義して現在のタ
 
 ユーザー定義のタイムゾーンを考慮するメソッドを用いて日付を比較したい場合、`Date.today`ではなく必ず`Date.current`を使ってください。ユーザー定義のタイムゾーンは、システムのタイムゾーンより未来になる可能性があります（`Date.today`はデフォルトでシステムのタイムゾーンを使います）。つまり、`Date.today`が`Date.yesterday`と等しくなる可能性があるということです。
 
-NOTE: 定義は[`active_support/core_ext/date/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date/calculations.rb)にあります。
 
 [Date.current]: https://api.rubyonrails.org/classes/Date.html#method-c-current
 [Date.tomorrow]: https://api.rubyonrails.org/classes/Date.html#method-c-tomorrow
@@ -3186,7 +3186,7 @@ d.end_of_week(:sunday)       # => Sat, 08 May 2010
 
 [`at_beginning_of_week`][DateAndTime::Calculations#at_beginning_of_week]は`beginning_of_week`のエイリアス、[`at_end_of_week`][DateAndTime::Calculations#at_end_of_week]は`end_of_week`のエイリアスです。
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [`config.beginning_of_week`]: configuring.html#config-beginning-of-week
 [DateAndTime::Calculations#at_beginning_of_week]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-at_beginning_of_week
@@ -3210,7 +3210,7 @@ d = Date.new(2012, 9, 16)    # => Sun, 16 Sep 2012
 d.sunday                     # => Sun, 16 Sep 2012
 ```
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateAndTime::Calculations#monday]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-monday
 [DateAndTime::Calculations#sunday]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-sunday
@@ -3237,7 +3237,7 @@ d.prev_week(:friday)     # => Fri, 30 Apr 2010
 
 `Date.beginning_of_week`または`config.beginning_of_week`が設定されていれば、`next_week`と`prev_week`はどちらも正常に動作します。
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [Date.beginning_of_week]: https://api.rubyonrails.org/classes/Date.html#method-c-beginning_of_week
 [DateAndTime::Calculations#last_week]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-last_week
@@ -3256,7 +3256,7 @@ d.end_of_month           # => Mon, 31 May 2010
 
 [`at_beginning_of_month`][DateAndTime::Calculations#at_beginning_of_month]は`beginning_of_month`のエイリアス、[`at_end_of_month`][DateAndTime::Calculations#at_end_of_month]は`end_of_month`のエイリアスです。
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateAndTime::Calculations#at_beginning_of_month]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-at_beginning_of_month
 [DateAndTime::Calculations#at_end_of_month]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-at_end_of_month
@@ -3282,7 +3282,7 @@ d.end_of_quarter         # => Wed, 30 Jun 2010
 
 [`at_beginning_of_quarter`][DateAndTime::Calculations#at_beginning_of_quarter]は`beginning_of_quarter`のエイリアス、[`at_end_of_quarter`][DateAndTime::Calculations#at_end_of_quarter]は`end_of_quarter`のエイリアスです。
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateAndTime::Calculations#quarter]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-quarter
 [DateAndTime::Calculations#at_beginning_of_quarter]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-at_beginning_of_quarter
@@ -3302,7 +3302,7 @@ d.end_of_year            # => Fri, 31 Dec 2010
 
 [`at_beginning_of_year`][DateAndTime::Calculations#at_beginning_of_year]は`beginning_of_year`のエイリアス、[`at_end_of_year`][DateAndTime::Calculations#at_end_of_year]は`end_of_year`のエイリアスです。
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateAndTime::Calculations#at_beginning_of_year]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-at_beginning_of_year
 [DateAndTime::Calculations#at_end_of_year]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-at_end_of_year
@@ -3336,7 +3336,7 @@ Date.new(2012, 2, 29).years_since(3)   # => Sat, 28 Feb 2015
 
 [`last_year`][DateAndTime::Calculations#last_year]は`#years_ago(1)`のショートハンドです。
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateAndTime::Calculations#last_year]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-last_year
 [DateAndTime::Calculations#years_ago]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-years_ago
@@ -3360,7 +3360,7 @@ Date.new(2009, 12, 31).months_since(2) # => Sun, 28 Feb 2010
 
 [`last_month`][DateAndTime::Calculations#last_month]は`#months_ago(1)`のショートハンドです。
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateAndTime::Calculations#last_month]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-last_month
 [DateAndTime::Calculations#months_ago]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-months_ago
@@ -3375,7 +3375,7 @@ Date.new(2010, 5, 24).weeks_ago(1)   # => Mon, 17 May 2010
 Date.new(2010, 5, 24).weeks_since(2) # => Mon, 07 Jun 2010
 ```
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateAndTime::Calculations#weeks_ago]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-weeks_ago
 [DateAndTime::Calculations#weeks_since]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-weeks_since
@@ -3392,7 +3392,7 @@ date.advance(months: 2, days: -2) # => Wed, 04 Aug 2010
 
 上の例にも示されているように、増分値には負の数も指定できます。
 
-NOTE: 定義は[`active_support/core_ext/date/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date/calculations.rb)にあります。
 
 [Date#advance]: https://api.rubyonrails.org/classes/Date.html#method-i-advance
 
@@ -3412,7 +3412,7 @@ Date.new(2010, 1, 31).change(month: 2)
 # => ArgumentError: invalid date
 ```
 
-NOTE: 定義は[`active_support/core_ext/date/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date/calculations.rb)にあります。
 
 [Date#change]: https://api.rubyonrails.org/classes/Date.html#method-i-change
 
@@ -3460,7 +3460,7 @@ date.end_of_day # => Mon Jun 07 23:59:59 +0200 2010
 
 [`at_beginning_of_day`][Date#at_beginning_of_day]と[`midnight`][Date#midnight]と[`at_midnight`][Date#at_midnight]は、`beginning_of_day`のエイリアスです。
 
-NOTE: 定義は[`active_support/core_ext/date/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date/calculations.rb)にあります。
 
 [Date#at_beginning_of_day]: https://api.rubyonrails.org/classes/Date.html#method-i-at_beginning_of_day
 [Date#at_midnight]: https://api.rubyonrails.org/classes/Date.html#method-i-at_midnight
@@ -3486,7 +3486,7 @@ date.end_of_hour # => Mon Jun 07 19:59:59 +0200 2010
 
 [`at_beginning_of_hour`][DateTime#at_beginning_of_hour]は`beginning_of_hour`のエイリアスです。
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 ##### `beginning_of_minute`、`end_of_minute`
 
@@ -3508,7 +3508,7 @@ date.end_of_minute # => Mon Jun 07 19:55:59 +0200 2010
 
 INFO: `beginning_of_hour`、`end_of_hour`、`beginning_of_minute`、`end_of_minute`は、`Time`および`DateTime`向けの実装ですが、`Date`向けの実装では**ありません**。時刻情報を含まない`Date`インスタンスに対して時間や分の最初や最後を問い合わせる意味はありません。
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateTime#at_beginning_of_minute]: https://api.rubyonrails.org/classes/DateTime.html#method-i-at_beginning_of_minute
 [DateTime#beginning_of_minute]: https://api.rubyonrails.org/classes/DateTime.html#method-i-beginning_of_minute
@@ -3530,7 +3530,7 @@ date = Date.current # => Fri, 11 Jun 2010
 date.since(1)       # => Fri, 11 Jun 2010 00:00:01 EDT -04:00
 ```
 
-NOTE: 定義は[`active_support/core_ext/date/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date/calculations.rb)にあります。
 
 [Date#ago]: https://api.rubyonrails.org/classes/Date.html#method-i-ago
 [Date#since]: https://api.rubyonrails.org/classes/Date.html#method-i-since
@@ -3576,7 +3576,7 @@ WARNING: `DateTime`は夏時間 (DST) ルールについては関知しません
 
 Active Supportでは、[`DateTime.current`][DateTime.current]を`Time.now.to_datetime`と同様に定義しています。ただし、`DateTime.current`はユーザータイムゾーンが定義されている場合に対応する点が異なります。インスタンスでは[`past?`][DateAndTime::Calculations#past?]および[`future?`][DateAndTime::Calculations#future?]という述語メソッドを利用でき、これらの定義は`Date.current`を起点としています。
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateTime.current]: https://api.rubyonrails.org/classes/DateTime.html#method-c-current
 
@@ -3591,7 +3591,7 @@ now = DateTime.current     # => Mon, 07 Jun 2010 20:26:36 +0000
 now.seconds_since_midnight # => 73596
 ```
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateTime#seconds_since_midnight]: https://api.rubyonrails.org/classes/DateTime.html#method-i-seconds_since_midnight
 
@@ -3606,7 +3606,7 @@ now.utc                # => Mon, 07 Jun 2010 23:27:52 +0000
 
 [`getutc`][DateTime#getutc]は`utc`のエイリアスです。
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateTime#getutc]: https://api.rubyonrails.org/classes/DateTime.html#method-i-getutc
 [DateTime#utc]: https://api.rubyonrails.org/classes/DateTime.html#method-i-utc
@@ -3621,7 +3621,7 @@ now.utc?          # => false
 now.utc.utc?      # => true
 ```
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateTime#utc?]: https://api.rubyonrails.org/classes/DateTime.html#method-i-utc-3F
 
@@ -3656,7 +3656,7 @@ d.advance(seconds: 1).advance(months: 1)
 
 WARNING: `DateTime`は夏時間 (DST) を考慮しません。算出された時間が最終的に存在しない時間になっても警告やエラーは発生しません。
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateTime#advance]: https://api.rubyonrails.org/classes/DateTime.html#method-i-advance
 [DateTime#since]: https://api.rubyonrails.org/classes/DateTime.html#method-i-since
@@ -3693,7 +3693,7 @@ DateTime.current.change(month: 2, day: 30)
 # => ArgumentError: invalid date
 ```
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateTime#change]: https://api.rubyonrails.org/classes/DateTime.html#method-i-change
 
@@ -3750,7 +3750,7 @@ Active Supportでは、[`Time.current`][Time.current]を定義して現在のタ
 
 ユーザー定義のタイムゾーンを考慮するメソッドを用いて時刻を比較したい場合、`Time.now`ではなく必ず`Time.current`を使ってください。ユーザー定義のタイムゾーンは、システムのタイムゾーンより未来になる可能性があります（`Time.now`はデフォルトでシステムのタイムゾーンを使います）。つまり、`Time.now.to_date`が`Date.yesterday`と等しくなる可能性があるということです。
 
-NOTE: 定義は[`active_support/core_ext/time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/time/calculations.rb)にあります。
 
 [DateAndTime::Calculations#next_day?]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-next_day-3F
 [DateAndTime::Calculations#prev_day?]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-prev_day-3F
@@ -3787,7 +3787,7 @@ now.all_year
 # => Fri, 01 Jan 2010 00:00:00 UTC +00:00..Fri, 31 Dec 2010 23:59:59 UTC +00:00
 ```
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateAndTime::Calculations#all_day]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-all_day
 [DateAndTime::Calculations#all_month]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-all_month
@@ -3806,7 +3806,7 @@ t.prev_day               # => 2010-05-07 00:00:00 +0900
 t.next_day               # => 2010-05-09 00:00:00 +0900
 ```
 
-NOTE: 定義は[`active_support/core_ext/time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/time/calculations.rb)にあります。
 
 [Time#next_day]: https://api.rubyonrails.org/classes/Time.html#method-i-next_day
 [Time#prev_day]: https://api.rubyonrails.org/classes/Time.html#method-i-prev_day
@@ -3830,7 +3830,7 @@ Time.new(2000, 5, 31).next_month # => 2000-06-30 00:00:00 +0900
 Time.new(2000, 1, 31).next_month # => 2000-02-29 00:00:00 +0900
 ```
 
-NOTE: 定義は[`active_support/core_ext/time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/time/calculations.rb)にあります。
 
 [Time#next_month]: https://api.rubyonrails.org/classes/Time.html#method-i-next_month
 [Time#prev_month]: https://api.rubyonrails.org/classes/Time.html#method-i-prev_month
@@ -3853,7 +3853,7 @@ t.prev_year               # => 1999-02-28 00:00:00 +0900
 t.next_year               # => 2001-02-28 00:00:00 +0900
 ```
 
-NOTE: 定義は[`active_support/core_ext/time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/time/calculations.rb)にあります。
 
 [Time#next_year]: https://api.rubyonrails.org/classes/Time.html#method-i-next_year
 [Time#prev_year]: https://api.rubyonrails.org/classes/Time.html#method-i-prev_year
@@ -3879,7 +3879,7 @@ Time.local(2000, 11, 31).next_quarter # => 2001-03-01 00:00:00 +0200
 
 [`last_quarter`][DateAndTime::Calculations#last_quarter]は`prev_quarter`のエイリアスです。
 
-NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/date_and_time/calculations.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/date_and_time/calculations.rb)にあります。
 
 [DateAndTime::Calculations#last_quarter]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-last_quarter
 [DateAndTime::Calculations#next_quarter]: https://api.rubyonrails.org/classes/DateAndTime/Calculations.html#method-i-next_quarter
@@ -3951,7 +3951,7 @@ WARNING: `atomic_write`は追記を行えません。
 
 この補助ファイルは標準の一時ファイル用ディレクトリに書き込まれますが、第2引数でディレクトリを直接指定することもできます。
 
-NOTE: 定義は[`active_support/core_ext/file/atomic.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/file/atomic.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/file/atomic.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/file/atomic.rb)にあります。
 
 [File.atomic_write]: https://api.rubyonrails.org/classes/File.html#method-c-atomic_write
 
@@ -3978,7 +3978,7 @@ rescue NameError => e
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/name_error.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/name_error.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/name_error.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/name_error.rb)にあります。
 
 [NameError#missing_name?]: https://api.rubyonrails.org/classes/NameError.html#method-i-missing_name-3F
 
@@ -4003,7 +4003,7 @@ rescue NameError => e
 end
 ```
 
-NOTE: 定義は[`active_support/core_ext/load_error.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/load_error.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/load_error.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/load_error.rb)にあります。
 
 [LoadError#is_missing?]: https://api.rubyonrails.org/classes/LoadError.html#method-i-is_missing-3F
 
@@ -4018,6 +4018,6 @@ NOTE: 定義は[`active_support/core_ext/load_error.rb`](https://github.com/rail
 content = Pathname.new("file").existence&.read
 ```
 
-NOTE: 定義は[`active_support/core_ext/pathname/existence.rb`](https://github.com/rails/rails/blob/7-1-stable/activesupport/lib/active_support/core_ext/pathname/existence.rb)にあります。
+NOTE: 定義は[`active_support/core_ext/pathname/existence.rb`](https://github.com/rails/rails/blob/8-0-stable/activesupport/lib/active_support/core_ext/pathname/existence.rb)にあります。
 
 [Pathname#existence]: https://api.rubyonrails.org/classes/Pathname.html#method-i-existence


### PR DESCRIPTION
RailsのActiveSupportに関するドキュメントのURLが更新されていなかったため、最新(v8.0)のURLに修正しました🙇