### PR TITLE
association_basics で不要な A をカット

### DIFF
--- a/guides/source/ja/association_basics.md
+++ b/guides/source/ja/association_basics.md
@@ -316,7 +316,7 @@ irb> raise_validation_error: Validation failed: Name can't be blank (ActiveRecor
 @book.author_previously_changed? # => true
 ```
 
-NOTE: A`model.association_changed?`と`model.association.changed?`を取り違えないようご注意ください。前者の`model.association_changed?`は、その関連付けが新しいレコードで置き換えられたかどうかをチェックしますが、後者の`model.association.changed?`は関連付けの「属性」が変更されたかどうかをチェックします。
+NOTE: `model.association_changed?`と`model.association.changed?`を取り違えないようご注意ください。前者の`model.association_changed?`は、その関連付けが新しいレコードで置き換えられたかどうかをチェックしますが、後者の`model.association.changed?`は関連付けの「属性」が変更されたかどうかをチェックします。
 
 ##### 既存の関連付けが存在するかどうかをチェックする
 


### PR DESCRIPTION
association_basics で不要な `A` をカットしました
![スクリーンショット 2024-11-15 16 09 26](https://github.com/user-attachments/assets/ebae3354-61e0-4bcc-8c0e-14adc4812da6)

参考: 
![スクリーンショット 2024-11-15 16 43 08](https://github.com/user-attachments/assets/be84ced0-4c2c-42f2-93f5-ae721afd851b)

MEMO:
過去バージョンには v7.2 のみ存在するようです（ #1771 で対応🛠)