### PR TITLE
v7.2 の association_basics で不要な A をカット

### DIFF
--- a/guides/source/ja/association_basics.md
+++ b/guides/source/ja/association_basics.md
@@ -316,7 +316,7 @@ irb> raise_validation_error: Validation failed: Name can't be blank (ActiveRecor
 @book.author_previously_changed? # => true
 ```
 
-NOTE: A`model.association_changed?`と`model.association.changed?`を取り違えないようご注意ください。前者の`model.association_changed?`は、その関連付けが新しいレコードで置き換えられたかどうかをチェックしますが、後者の`model.association.changed?`は関連付けの「属性」が変更されたかどうかをチェックします。
+NOTE: `model.association_changed?`と`model.association.changed?`を取り違えないようご注意ください。前者の`model.association_changed?`は、その関連付けが新しいレコードで置き換えられたかどうかをチェックしますが、後者の`model.association.changed?`は関連付けの「属性」が変更されたかどうかをチェックします。
 
 ##### 既存の関連付けが存在するかどうかをチェックする
 


### PR DESCRIPTION
v7.2 の association_basics で不要な A をカットしました
![スクリーンショット 2024-11-15 16 09 26](https://github.com/user-attachments/assets/769947c3-d35a-4d0e-ad8f-6f3677329578)

参考:
![スクリーンショット 2024-11-15 16 43 08](https://github.com/user-attachments/assets/1a9ce10b-e4bf-48f6-9d21-9b5ae3d2c0c4)

MEMO:
master (  #1770 で対応)と当バージョン以外には該当箇所はなさそうでした👀

CIパスしたらマージします🙏

