### PR TITLE
ruby_on_rails_guides_guidelines でバッククォートを追加

### DIFF
--- a/guides/source/ja/ruby_on_rails_guides_guidelines.md
+++ b/guides/source/ja/ruby_on_rails_guides_guidelines.md
@@ -102,7 +102,7 @@ WARNING: アプリのマスターキーは安全に保管すること。マス�
 
 リンクの文字列には、"here"や"more"といった書き方を避け、具体的な内容のわかる文字列を使うこと。
 
-``markdown
+```markdown
 # BAD
 See the Rails Internationalization (I18n) API documentation for [more
 details](i18n.html).


### PR DESCRIPTION
ruby_on_rails_guides_guidelines のコードブロック部分で、バッククォートの不足を修正しました🛠
CIが通ったらマージします🙏