### PR TITLE
Fix active_record_migrations.md

### DIFF
--- a/guides/source/ja/active_record_migrations.md
+++ b/guides/source/ja/active_record_migrations.md
@@ -345,7 +345,7 @@ create_table :products do |t|
 end
 ```
 
-上のマイグレーションによって`category_id`カラムが作成されます。以下のように、`belongs_to`の代わりに`references`をエイリアスとして使うことも可能です。
+上のマイグレーションによって`category_id`カラムが作成されます。以下のように、`references`の代わりに`belongs_to`をエイリアスとして使うことも可能です。
 
 ```ruby
 create_table :products do |t|


### PR DESCRIPTION
Rails ガイドをいつも参考にしています！
ありがとうございます🙇‍♂️

文章を読んでいると、`belongs_to` と `references` が逆かと思ったためプルリクエストを作成しました🙏
原著の対応部分は以下になります。

ご確認をよろしくお願いいたします。

> Alternatively, you can use `belongs_to` as an alias for `references`
【引用】https://guides.rubyonrails.org/active_record_migrations.html

<img src="https://github.com/user-attachments/assets/f75ccbea-f091-454e-bdc0-04cf13f2aed6" width="600">