### PR TITLE
[8.0.1] 7_1_release_notes.mdの原文更新を訳文に反映

### DIFF
--- a/guides/source/ja/7_1_release_notes.md
+++ b/guides/source/ja/7_1_release_notes.md
@@ -764,6 +764,8 @@ Active Record
 [#48930]: https://github.com/rails/rails/pull/48930
 [#49100]: https://github.com/rails/rails/pull/49100
 
+* `encrypts`で定義した属性で使われる`ActiveRecord::Encryption`のデフォルトのハッシュダイジェストが、デフォルト設定の`SHA1`から`SHA256`に変更された。これらのデフォルトには`support_sha1_for_non_deterministic_encryption = false` も含まれており、データが再暗号化されていない場合、アプリは古いデフォルトのハッシュダイジェストで暗号化されたデータを復号化できなくなる可能性がある。
+
 Active Storage
 --------------
 


### PR DESCRIPTION
https://github.com/yasslab/railsguides.jp/issues/1790

これはv7.1、v7.2にもバックポートします。