### PR TITLE
Fix a line of "config.logger"

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -559,7 +559,7 @@ Railsのログ出力をどのぐらい詳細にするかを指定します。デ
 
 * フォーマッターをサポートする場合は、`config.log_formatter`の値を手動でロガーに代入しなければなりません。
 * タグ付きログをサポートする場合は、そのログのインスタンスを`ActiveSupport::TaggedLogging`でラップしなければなりません。
-* ログ出力の抑制をサポートするには、`LoggerSilence`モジュールを`include`しなければなりません。`ActiveSupport::Logger`クラスは既にこれらのモジュールに`include`されています。
+* ログ出力の抑制をサポートするには、`LoggerSilence`モジュールを`include`しなければなりません。`ActiveSupport::Logger`クラスは既にこれらのモジュールを`include`しています。
 
 ```ruby
 class MyLogger < ::Logger


### PR DESCRIPTION
[Active Job の基礎の「3.2.44 config.logger」](https://railsguides.jp/configuring.html#config-logger)について、[対応する本家ガイド](https://guides.rubyonrails.org/configuring.html#config-logger)と比較して、一行修正を行いました。