### PR TITLE
SOLID QUEUE -> Solid Queue に統一します

### DIFF
--- a/guides/source/ja/active_job_basics.md
+++ b/guides/source/ja/active_job_basics.md
@@ -518,7 +518,7 @@ ProcessVideoJob.perform_later(Video.last)
 MyJob.set(queue: :another_queue).perform_later(record)
 ```
 
-NOTE: [SOLID QUEUE以外の一部のバックエンド](#代替キューイングバックエンド
+NOTE: [Solid Queue以外の一部のバックエンド](#代替キューイングバックエンド
 )では、リッスンするキューを指定する必要が生じることもあります。
 
 [`config.active_job.queue_name_delimiter`]:


### PR DESCRIPTION
`SOLID QUEUE` -> `Solid Queue` に統一します

```sh
❯ git grep "SOLID QUEUE"
guides/source/ja/active_job_basics.md:NOTE: [SOLID QUEUE以外の一部のバックエンド](#代替キューイングバックエンド
```

該当箇所は上記の1箇所でした。