### PR TITLE
ビルドエラー確認: v6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,5 @@ Railsガイドの[コンテンツ部分](https://github.com/yasslab/railsguides.
 - 本書: [https://railsguides.jp/#contributors](https://railsguides.jp/#contributors)
 
 [![YassLab Inc.](https://yasslab.jp/img/logos/800x200.png)](https://yasslab.jp/ja/)
+
+<!-- IC動作確認 -->


### PR DESCRIPTION
過去ブランチ（v6.1, v6.0）の更新でCIでエラーが起こりました。
ログが消えていまっているので、エラー確認のPRです。

適宜対応していきます。