### PR TITLE
distinctとorderの組み合わせでエラーが起きるところの説明がおかしいのを直した

### DIFF
--- a/guides/source/ja/active_record_querying.md
+++ b/guides/source/ja/active_record_querying.md
@@ -944,7 +944,7 @@ Book.includes(:author).order(books: { print_year: :desc }, authors: { name: :asc
 Book.includes(:author).order("books.print_year desc", "authors.name asc")
 ```
 
-WARNING: 多くのデータベースシステムでは、`select`、`pluck`、`ids`メソッドを使ってフィールドを選択しています。これらのデータベースシステムでは、選択しているリストに`order`句を使ったフィールドが含まれていないと、`order`メソッドで`ActiveRecord::StatementInvalid`例外が発生します。結果から特定のフィールドを取り出す方法については、次のセクションを参照してください。
+WARNING: 多くのデータベースシステムでは、`select`、`pluck`、`ids`メソッドを使った結果に対して`distinct`を利用して絞り込んだとき、`order`句で指定したフィールドがselectのリストに含まれていないと`ActiveRecord::StatementInvalid`例外が発生します。結果から特定のフィールドを取り出す方法については、次のセクションを参照してください。
 
 特定のフィールドだけを取り出す
 -------------------------


### PR DESCRIPTION
原文: [Active Record Query Interface — Ruby on Rails Guides](https://guides.rubyonrails.org/active_record_querying.html#ordering)

<img width="838" alt="image" src="https://github.com/user-attachments/assets/a07ab1e5-823e-4a89-a61d-424c1d70314f" />

`distinct`が通常の英単語として翻訳された結果、意味が正しく取れていない状態になっています。実際には差分のように、`distinct`と`select`(や`pluck`や`ids`など)と`order`を組み合わせたときに`ActiveRecord::StatementInvalid`の挙動になるようです。`select`と`order`ではエラーにはなりませんでした(MySQL9.2.0, PostgreSQL16で挙動を確認)。