### PR TITLE
active_record_composite_primary_keys.mdの欠落箇所を修正

### DIFF
--- a/guides/source/ja/active_record_composite_primary_keys.md
+++ b/guides/source/ja/active_record_composite_primary_keys.md
@@ -223,7 +223,7 @@ SELECT * FROM authors WHERE first_name = 'Jane' AND last_name = 'Doe'
 複合主キーのパラメータ
 ------------------------
 
-れているため、各値を抽出してActive Recordに渡す必要があります。このユースケースでは、`extract_value`メソッドを活用できます。
+複合キーパラメータは1個のパラメータに複数の値が含まれているため、各値を抽出してActive Recordに渡す必要があります。このユースケースでは、`extract_value`メソッドを活用できます。
 
 以下のコントローラがあるとします。
 


### PR DESCRIPTION
## 概要
* 訳文に欠落している箇所がありましたので修正しました
  * 元の訳文があればとおもい履歴を追いましたが、初出時(複合主キーが対応された7.1)からのようでした
    * https://github.com/yasslab/railsguides.jp/pull/1512/files#diff-71cd7a4e445d8e591a0d0b773406220343dfbf636a3f78d597fa82bb6bbe4fb5R211
* 後続の、「れているため」に繋がる形の文にしています
* 「Action Controller の概要」ページ「複合主キーのパラメータ」セクションの説明文とマッチするようにしています


## 英語原文
> Composite key parameters contain multiple values in one parameter. For this reason, we need to be able to extract each value and pass them to Active Record. We can leverage the `extract_value` method for this use-case.

[リンク](https://guides.rubyonrails.org/v8.0/active_record_composite_primary_keys.html#:~:text=Composite%20key%20parameters%20contain%20multiple%20values%20in%20one%20parameter.%20For%20this%20reason%2C%20we%20need%20to%20be%20able%20to%20extract%20each%20value%20and%20pass%20them%20to%20Active%20Record.%20We%20can%20leverage%20the%20extract_value%20method%20for%20this%20use%2Dcase.)

## 「Action Controller の概要」ページ「複合主キーのパラメータ」セクションの説明文
> 複合キーパラメータは、1個のパラメータに複数の値を含み、値同士は区切り文字（アンダースコアなど）で区切られます。したがって、Active Recordに渡すには個別の値を抽出する必要があります。これを行うには、extract_valueメソッドを使います。

[リンク](https://railsguides.jp/action_controller_overview.html#%E8%A4%87%E5%90%88%E4%B8%BB%E3%82%AD%E3%83%BC%E3%81%AE%E3%83%91%E3%83%A9%E3%83%A1%E3%83%BC%E3%82%BF)

---

Railsガイドいつもありがたく活用させていただいております。皆様ありがとうございます :pray: