### PR TITLE
Fix typo in asset_pipeline.md

### DIFF
--- a/guides/source/ja/asset_pipeline.md
+++ b/guides/source/ja/asset_pipeline.md
@@ -570,7 +570,7 @@ const greet = (name) => {
 };
 ```
 
-従来は、CSS変数やネストなどのCSS機能を利用するために[Sass](https://sass-lang.com/)や[Less](https://lesscss.org/)といったプリプロセッサが不可欠でした。現在、最新のCS はこれらをネイティブにサポートしており、トランスパイルの必要性は薄れています。
+従来は、CSS変数やネストなどのCSS機能を利用するために[Sass](https://sass-lang.com/)や[Less](https://lesscss.org/)といったプリプロセッサが不可欠でした。現在、最新のCSSはこれらをネイティブにサポートしており、トランスパイルの必要性は薄れています。
 
 #### バンドル❌
 


### PR DESCRIPTION
typo を見つけたため修正します

本家は正しい状態だったため日本語版の修正のみPRを出します
https://github.com/rails/rails/blob/main/guides/source/asset_pipeline.md?plain=1#L817