### PR TITLE
Fix broken link to CoC

### DIFF
--- a/guides/source/ja/contributing_to_ruby_on_rails.md
+++ b/guides/source/ja/contributing_to_ruby_on_rails.md
@@ -16,7 +16,7 @@ Ruby on Railsは、「どこかで誰かがうまくやってくれているフ�
 [RailsのREADME][README]にも記載されているように、Railsのコードベースやサブプロジェクトのコードベースについて、issueトラッカーやチャットルーム、discussionボード、メーリングリストでやり取りする方はすべて、Railsの[行動規範][CoC]に従うことが期待されます。
 
 [README]: https://github.com/rails/rails/blob/main/README.md
-[CoC]: https://rubyonrails.org/conduct/
+[CoC]: https://rubyonrails.org/conduct
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
## 概要

[Ruby on Rails に貢献する方法](https://railsguides.jp/contributing_to_ruby_on_rails.html)の冒頭にある「Railsの**行動規範**に従うことが期待されます。」のリンクが機能しなくなっていたので修正を提案します。

[原著版](https://guides.rubyonrails.org/contributing_to_ruby_on_rails.html)では、リンクが正しく機能していました。

### 修正内容

- before: https://rubyonrails.org/conduct/
- after: https://rubyonrails.org/conduct