### PR TITLE
Fix msgpack link at 7_1_release_notes.md

### DIFF
--- a/guides/source/ja/7_1_release_notes.md
+++ b/guides/source/ja/7_1_release_notes.md
@@ -192,7 +192,7 @@ ENV["DATABASE_URL"] # => "trilogy://localhost/blog_development?pool=5"
 
 ### `ActiveSupport::MessagePack`が追加
 
-[`ActiveSupport::MessagePack`][]は、[`msgpack`][] gemと統合されたシリアライザです（[#47770][]）。`ActiveSupport::MessagePack`は、`msgpack`でサポートされている基本的なRubyの型に加えて、`Time`、`ActiveSupport::TimeWithZone`、`ActiveSupport::HashWithIndifferentAccess`などの追加の型もシリアライズできます。`ActiveSupport::MessagePack`は、`JSON`や`Marshal`に比べてペイロードサイズを削減しパフォーマンスを向上させることが可能です。
+[`ActiveSupport::MessagePack`][]は、[`msgpack`](https://github.com/msgpack/msgpack-ruby) gemと統合されたシリアライザです（[#47770][]）。`ActiveSupport::MessagePack`は、`msgpack`でサポートされている基本的なRubyの型に加えて、`Time`、`ActiveSupport::TimeWithZone`、`ActiveSupport::HashWithIndifferentAccess`などの追加の型もシリアライズできます。`ActiveSupport::MessagePack`は、`JSON`や`Marshal`に比べてペイロードサイズを削減しパフォーマンスを向上させることが可能です。
 
 `ActiveSupport::MessagePack`は、以下のように[メッセージシリアライザ](configuring.html#config-active-support-message-serializer)として利用できます。
 

--- a/guides/source/ja/7_1_release_notes.md
+++ b/guides/source/ja/7_1_release_notes.md
@@ -192,7 +192,7 @@ ENV["DATABASE_URL"] # => "trilogy://localhost/blog_development?pool=5"
 
 ### `ActiveSupport::MessagePack`が追加
 
-[`ActiveSupport::MessagePack`][]は、[`msgpack`](https://github.com/msgpack/msgpack-ruby) gemと統合されたシリアライザです（[#47770][]）。`ActiveSupport::MessagePack`は、`msgpack`でサポートされている基本的なRubyの型に加えて、`Time`、`ActiveSupport::TimeWithZone`、`ActiveSupport::HashWithIndifferentAccess`などの追加の型もシリアライズできます。`ActiveSupport::MessagePack`は、`JSON`や`Marshal`に比べてペイロードサイズを削減しパフォーマンスを向上させることが可能です。
+[`ActiveSupport::MessagePack`][]は、[`msgpack`][] gemと統合されたシリアライザです（[#47770][]）。`ActiveSupport::MessagePack`は、`msgpack`でサポートされている基本的なRubyの型に加えて、`Time`、`ActiveSupport::TimeWithZone`、`ActiveSupport::HashWithIndifferentAccess`などの追加の型もシリアライズできます。`ActiveSupport::MessagePack`は、`JSON`や`Marshal`に比べてペイロードサイズを削減しパフォーマンスを向上させることが可能です。
 
 `ActiveSupport::MessagePack`は、以下のように[メッセージシリアライザ](configuring.html#config-active-support-message-serializer)として利用できます。
 
@@ -220,7 +220,7 @@ ActiveSupport::Cache.lookup_store(:file_store, "tmp/cache", serializer: :message
 ```
 
 [`ActiveSupport::MessagePack`]: https://api.rubyonrails.org/v7.1/classes/ActiveSupport/MessagePack.html
-[`msgpack` gem]: https://github.com/msgpack/msgpack-ruby
+[`msgpack`]: https://github.com/msgpack/msgpack-ruby
 
 [#47770]: https://github.com/rails/rails/pull/47770
 [#48103]: https://github.com/rails/rails/pull/48103


### PR DESCRIPTION
# 概要
`guides/source/7_1_release_notes.md` にて原著のほうで貼られていたmsgpack gemへのリンクがなかったので原著と同じリンクを追加しました

**原著該当ページ**
https://guides.rubyonrails.org/7_1_release_notes.html#add-activesupport-messagepack

**本書該当ページ**
https://railsguides.jp/7_1_release_notes.html#activesupport-messagepack%E3%81%8C%E8%BF%BD%E5%8A%A0