### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Railsガイドの[コンテンツ部分](https://github.com/yasslab/railsguides.
 
 ## ©️ クレジット
 
-- 原著: [https://edgeguides.rubyonrails.org/#footer](https://edgeguides.rubyonrails.org/#footer)
+- 原著: [https://edgeguides.rubyonrails.org/#complementary](https://edgeguides.rubyonrails.org/#complementary)
 - 本書: [https://railsguides.jp/#contributors](https://railsguides.jp/#contributors)
 
 [![YassLab Inc.](https://yasslab.jp/img/logos/800x200.png)](https://yasslab.jp/ja/)


### PR DESCRIPTION
クレジットの原著へのリンクが変更されていたので修正しました

## 修正内容
昔のデザインの#footerにリンクが貼られていたのでその部分を確認したのち、現状のデザインで同様の該当場所にリンクを貼りました
https://web.archive.org/web/20181105025931/https://edgeguides.rubyonrails.org/

**該当箇所画像**
![スクリーンショット 2025-02-10 23 34 15](https://github.com/user-attachments/assets/8eae6449-72d8-4201-b473-e766ec1bdcd1)

