### PR TITLE
ActiveRecordの関連付け has_one 誤訳を修正

### DIFF
--- a/guides/source/ja/association_basics.md
+++ b/guides/source/ja/association_basics.md
@@ -484,7 +484,7 @@ irb> raise_validation_error: Validation failed: Terms can't be blank (ActiveReco
 
 ```ruby
 if @supplier.account.nil?
-  @msg = "この本の著者が見つかりません"
+  @msg = "この供給元のアカウントが見つかりません"
 end
 ```
 


### PR DESCRIPTION
- 対象ページ
[2.2.1.3 既存の関連付けが存在するかどうかをチェックする](https://railsguides.jp/association_basics.html#has-one%E3%81%A7%E8%BF%BD%E5%8A%A0%E3%81%95%E3%82%8C%E3%82%8B%E3%83%A1%E3%82%BD%E3%83%83%E3%83%89-%E6%97%A2%E5%AD%98%E3%81%AE%E9%96%A2%E9%80%A3%E4%BB%98%E3%81%91%E3%81%8C%E5%AD%98%E5%9C%A8%E3%81%99%E3%82%8B%E3%81%8B%E3%81%A9%E3%81%86%E3%81%8B%E3%82%92%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF%E3%81%99%E3%82%8B)

以下の`@msg`の内容が例示されているモデルと食い違っているように思いました。

```ruby
# supplierとaccountを例としているが、@msgの中身は本と著者になっている
if @supplier.account.nil?
  @msg = "この本の著者が見つかりません"
end
```

本家の[2.2.1.3. Checking for Existing Associations](https://guides.rubyonrails.org/association_basics.html#methods-added-by-has-one-checking-for-existing-associations)も確認したところ、
> "No account found for this supplier"

となっていましたので、本家に沿った訳文に修正提案させていただきます。

---
Railsガイド、Railsチュートリアルの運営いつもありがとうございます！