### PR TITLE
YAMLキーdevelopment:の誤記を修正しました

### DIFF
--- a/guides/source/ja/active_job_basics.md
+++ b/guides/source/ja/active_job_basics.md
@@ -140,7 +140,7 @@ config.solid_queue.connects_to = { database: { writing: :queue } }
 
 ```yaml
 # config/database.yml
-development
+development:
   primary:
     <<: *default
     database: storage/development.sqlite3


### PR DESCRIPTION
3.1.1 development環境の場合
config/database.yml
development -> development: