### PR TITLE
getting_started.mdのrich_text_areaをrich_textareaに修正

### DIFF
--- a/guides/source/ja/getting_started.md
+++ b/guides/source/ja/getting_started.md
@@ -1533,7 +1533,7 @@ end
 
   <div>
     <%= form.label :description, style: "display: block" %>
-    <%= form.rich_text_area :description %>
+    <%= form.rich_textarea :description %>
   </div>
 
   <div>


### PR DESCRIPTION
## 修正内容

getting_started.mdの`rich_text_area`を`rich_textarea`に修正しました。
CIがパスしたらマージします。

## 背景

https://x.com/GhostBrain/status/1920758919070204039
https://x.com/GhostBrain/status/1920759321391943731

上のツイートをきっかけに調べたところ、Rails 8では[#52467](https://github.com/rails/rails/pull/52467)で`text_area`を`textarea`に、`rich_text_area`を`rich_textarea`にリネームされています（ただし古い名前もエイリアスとして残されているので一応有効です）。

- https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-textarea
- https://api.rubyonrails.org/classes/ActionView/Helpers/FormBuilder.html#method-i-rich_textarea

Railsガイドは、`text_area`->`textarea`は既にRails 8ですべて反映済みであり、追加修正は不要です。

しかし`rich_text_area`->`rich_textarea`については原文が1箇所修正漏れになっていることがわかったため、このプルリクでひとまず訳文を修正します。その後原文にも修正プルリクを投げます。