### PR TITLE
[7.2] 単一テスト実行時の-nオプションの修正

### DIFF
--- a/guides/source/ja/contributing_to_ruby_on_rails.md
+++ b/guides/source/ja/contributing_to_ruby_on_rails.md
@@ -491,7 +491,7 @@ $ bundle exec rake TEST=test/cases/associations/has_many_associations_test.rb
 
 #### テストでデバッガを使う
 
-外部デバッガ（pry、byebugなど）を利用する場合は、デバッガをインストールして通常どおりに使います。デバッガの問題が発生した場合は、`PARALLEL_WORKERS=1`を設定してテストをシリアル実行するか、`n test_long_test_name`で単一のテストを実行してください。
+外部デバッガ（pry、byebugなど）を利用する場合は、デバッガをインストールして通常どおりに使います。デバッガの問題が発生した場合は、`PARALLEL_WORKERS=1`を設定してテストをシリアル実行するか、`-n test_long_test_name`で単一のテストを実行してください。
 
 ジェネレータに対してテストを実行する場合、デバッグツールが機能するために`RAILS_LOG_TO_STDOUT=true`を設定する必要があります。
 


### PR DESCRIPTION
# 概要

単一テスト実行時の`-n`オプションの誤記を修正させていただきました🙏 

# 参考

[[Railsガイド v7.2] 5.7.5 テストを1件だけ実行する](https://railsguides.jp/v7.2/contributing_to_ruby_on_rails.html#%E3%83%86%E3%82%B9%E3%83%88%E3%82%921%E4%BB%B6%E3%81%A0%E3%81%91%E5%AE%9F%E8%A1%8C%E3%81%99%E3%82%8B)

[[原著 v7.2] 5.7.10. Using Debuggers with Test](https://guides.rubyonrails.org/v7.2/contributing_to_ruby_on_rails.html#using-debuggers-with-test)

# 関連

https://github.com/yasslab/railsguides.jp/pull/1844
https://github.com/yasslab/railsguides.jp/pull/1846