### PR TITLE
`config.active_support.deprecation` の訳を改善

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -2626,7 +2626,7 @@ config.active_support.message_serializer = YAML
 
 非推奨警告メッセージの振る舞いを設定します。指定可能なオプションについては[`Deprecation::Behavior`][deprecation_behavior]を参照してください。
 
-デフォルトで生成される`config/environments`以下のファイルでは、development環境では`:log`が、test環境では`:stderr`がそれぞれ設定されます。production環境ではこの設定は無視され、[`config.active_support.report_deprecations`] (#config-active-support-report-deprecations)の設定が使われます。
+デフォルトで生成される`config/environments`以下のファイルでは、development環境では`:log`が、test環境では`:stderr`がそれぞれ設定されます。production環境ではこの設定は省略されており、[`config.active_support.report_deprecations`] (#config-active-support-report-deprecations)の設定が使われます。
 
 [deprecation_behavior]: https://api.rubyonrails.org/classes/ActiveSupport/Deprecation/Behavior.html#method-i-behavior-3D
 


### PR DESCRIPTION
v7.1以降の`config.active_support.deprecation`の項目内の以下の訳についてです

https://railsguides.jp/v7.1/configuring.html#config-active-support-deprecation

> デフォルトで生成される`config/environments`以下のファイルでは、development環境では`:log`が、test環境では`:stderr`がそれぞれ設定されます。production環境ではこの設定は無視され、[`config.active_support.report_deprecations`](https://railsguides.jp/v7.1/configuring.html#config-active-support-report-deprecations)の設定が使われます。

https://guides.rubyonrails.org/v7.1/configuring.html#config-active-support-deprecation

> In the default generated `config/environments` files, this is set to `:log` for development and `:stderr` for test, and it is omitted for production in favor of [`config.active_support.report_deprecations`](https://guides.rubyonrails.org/v7.1/configuring.html#config-active-support-report-deprecations).

'omitted' が「無視され」と訳されていますが、`config/environments/production.rb`内で`config.active_support.deprecation = :log`のように設定しても反映されないと解釈できてしまいます。しかし、原著に該当部分の記述が追加された https://github.com/rails/rails/pull/46457 において、

> This updates the description of several deprecation-related configuration settings to explain that their "default" values are from the default generated `config/environments` files, and that those values vary by environment.

とあることから、'omitted'の解釈としては、「`rails new`で作成された`config/environments/production.rb`の中では`config.active_support.deprecation`はデフォルトで**省略されている**（代わりに`config.active_support.report_deprecations`が使われている）」というニュアンスが正しいと思います