### PR TITLE
サンプルコードの掲載誤りの修正

### DIFF
--- a/guides/source/ja/active_record_validations.md
+++ b/guides/source/ja/active_record_validations.md
@@ -1573,10 +1573,14 @@ irb> person.errors.where(:name, :too_short, minimum: 3)
 これらのエラーオブジェクトから、さまざまな情報を読み出せます。
 
 ```irb
-irb> error.message
-#=> "is too short (minimum is 3 characters)"
-irb> error.full_message
-#=> "Name is too short (minimum is 3 characters)"
+irb> error = person.errors.where(:name).last
+
+irb> error.attribute
+=> :name
+irb> error.type
+=> :too_short
+irb> error.options[:count]
+=> 3
 ```
 
 エラーメッセージを生成することも可能です。


### PR DESCRIPTION
## 概要
サンプルコードが原文と異なり、1つ下のサンプルコードと全く同じ内容になっている箇所がありました。
原文と同じ内容に修正することを提案します。

## 参考
- 7.3 errors.whereとエラーオブジェクト（Active Record バリデーション - Railsガイド）https://railsguides.jp/active_record_validations.html#errors-whereとエラーオブジェクト
- 原文のサンプルコード
https://github.com/rails/rails/blob/c72f6713a427851a20a46c00c8ef3ab689d5bd32/guides/source/active_record_validations.md?plain=1#L1769-L1778