### PR TITLE
Update 8_0_release_notes.md

### DIFF
--- a/guides/source/ja/8_0_release_notes.md
+++ b/guides/source/ja/8_0_release_notes.md
@@ -108,7 +108,7 @@ Action Pack
 
 ### 主な変更
 
-*   従来よりも安全かつ明示的なパラメータ処理メソッドである[`params#expect`](https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-expect)が導入されました。従来の`params.expect(table: [ :attr ])`をシンプルな`params.require(:table).permit(:attr)`に置き換えられます。
+*   従来よりも安全かつ明示的なパラメータ処理メソッドである[`params#expect`](https://api.rubyonrails.org/classes/ActionController/Parameters.html#method-i-expect)が導入されました。従来の`params.require(:table).permit(:attr)`を`params.expect(table: [ :attr ])`に置き換えられるようになります。
 
 Action View
 -----------


### PR DESCRIPTION
https://railsguides.jp/8_0_release_notes.html#action-pack-%E4%B8%BB%E3%81%AA%E5%A4%89%E6%9B%B4
> 従来よりも安全かつ明示的なパラメータ処理メソッドである[params#expect](https://api.rubyonrails.org/v8.1/classes/ActionController/Parameters.html#method-i-expect)が導入されました。従来のparams.expect(table: [ :attr ])をシンプルなparams.require(:table).permit(:attr)に置き換えられます。

上記翻訳が逆になっていたので修正しました。

参考: https://guides.rubyonrails.org/8_0_release_notes.html#action-pack-notable-changes