### PR TITLE
Remove 'Copilot menu' from YAML example

### DIFF
--- a/guides/source/ja/sign_up_and_settings.md
+++ b/guides/source/ja/sign_up_and_settings.md
@@ -1557,7 +1557,6 @@ end
 ```yaml
 <% password_digest = BCrypt::Password.create("password") %>
 one:
-Copilot menu
   email_address: one@example.com
   password_digest: <%= password_digest %>
   first_name: User


### PR DESCRIPTION
不要な「Copilot menu」の文字列を削除