### PR TITLE
configuring.md で余分なクオートをカット

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -2275,7 +2275,7 @@ end
 
 値を`:rescueable`に設定すると、[`config.action_dispatch.rescue_responses`](#config-action-dispatch-rescue-responses)リストで定義されている例外についてはrescueし、その他すべてはraiseするようAction Packを構成します。たとえば、Action Packは`ActiveRecord::RecordNotFound`をrescueしますが、`NoMethodError`をraiseします。
 
-値を``:none`に設定すると、Action Packがすべての例外をraiseするように構成されます。
+値を`:none`に設定すると、Action Packがすべての例外をraiseするように構成されます。
 
 * `:all`: すべての例外をエラーページで表示する
 * `:rescuable`: [`config.action_dispatch.rescue_responses`](#config-action-dispatch-rescue-responses)で宣言されている例外をエラーページで表示する


### PR DESCRIPTION
configuring.md で余分なクオートをカットしました✂️

🔽 該当箇所
<img width="878" height="222" alt="スクリーンショット 2025-12-05 18 00 50" src="https://github.com/user-attachments/assets/87a91e4f-eb84-4713-b62c-ff531c664284" />

🔽 更新後
<img width="836" height="120" alt="スクリーンショット 2025-12-10 14 07 56" src="https://github.com/user-attachments/assets/b53702d4-c8ce-45de-981e-84b3b126893c" />

こちらはCIがパスしたらマージします🛠️