### PR TITLE
v80のconfiguring.md で余分なクオートをカット

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -2089,7 +2089,7 @@ end
 
 値を`:rescueable`に設定すると、[`config.action_dispatch.rescue_responses`](#config-action-dispatch-rescue-responses)リストで定義されている例外についてはrescueし、その他すべてはraiseするようAction Packを構成します。たとえば、Action Packは`ActiveRecord::RecordNotFound`をrescueしますが、`NoMethodError`をraiseします。
 
-値を``:none`に設定すると、Action Packがすべての例外をraiseするように構成されます。
+値を`:none`に設定すると、Action Packがすべての例外をraiseするように構成されます。
 
 * `:all`: すべての例外をエラーページで表示する
 * `:rescuable`: [`config.action_dispatch.rescue_responses`](#config-action-dispatch-rescue-responses)で宣言されている例外をエラーページで表示する


### PR DESCRIPTION
v80のconfiguring.md で余分なクオートをカットしました✂️

#1921 と同様の更新です。
CIがパスしたらマージします🛠️