### PR TITLE
Active Record バリデーション解説のクラス名誤記を修正

### DIFF
--- a/guides/source/ja/active_record_validations.md
+++ b/guides/source/ja/active_record_validations.md
@@ -1466,7 +1466,7 @@ irb> user.save(context: :location_info) # => false
 
 [`errors`][]メソッドは、個別のエラーを詳しく掘り下げるときの入り口となります。
 
-`errors`メソッドは、すべてのエラーを含む`ActiveModel::Error`クラスのインスタンスを1つ返します。個別のエラーは、[`ActiveModel::Error`][]オブジェクトによって表現されます。
+`errors`メソッドは、すべてのエラーを含む`ActiveModel::Errors`クラスのインスタンスを1つ返します。個別のエラーは、[`ActiveModel::Error`][]オブジェクトによって表現されます。
 
 ```ruby
 class Person < ApplicationRecord


### PR DESCRIPTION
## 概要
[Active Record バリデーションガイド内の解説](https://railsguides.jp/active_record_validations.html#%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%82%A8%E3%83%A9%E3%83%BC%E3%81%AB%E5%AF%BE%E5%BF%9C%E3%81%99%E3%82%8B-errors)において、クラス名の誤記があったため修正しました。

## 修正内容
`errors` メソッドの返り値に関する説明文を修正しました。

- 修正前: `ActiveModel::Error` クラスのインスタンスを1つ返します。
- 修正後: `ActiveModel::Errors` クラスのインスタンスを1つ返します。

## 修正理由
- `errors` メソッドが返すオブジェクトは、個別のエラー（Error）ではなく、エラーのコレクション（Errors）であるためです。
- また[英語版Railsガイド](https://guides.rubyonrails.org/active_record_validations.html#errors)では、対応する箇所が`ActiveModel::Errors`と記載がありました。
  > This returns an instance of the class ActiveModel::Errors containing all errors, each error is represented by an [ActiveModel::Error](https://api.rubyonrails.org/v8.1.1/classes/ActiveModel/Error.html) object.