### PR TITLE
デフォルト値の記載を修正

### DIFF
--- a/guides/source/ja/configuring.md
+++ b/guides/source/ja/configuring.md
@@ -2003,7 +2003,7 @@ NOTE: この設定は、非推奨化されて今後のRailsバージョンで削
 | バージョン     | デフォルト値 |
 | -------------- | ------------ |
 | （オリジナル） | `:log`       |
-| 8.1以降        | `:raise`     |
+| 7.0以降        | `:raise`     |
 
 #### `config.action_controller.action_on_path_relative_redirect`
 


### PR DESCRIPTION
2か所のデフォルト値の記載が間違っていたので修正しました。


**`config.action_controller.action_on_open_redirect`**

8.1以降ではなく7.0以降で変更になっています。

> The default value depends on the `config.load_defaults` target version:
> 
> | Starting with version | The default value is |
> | --------------------- | -------------------- |
> | (original)            | `:log`               |
> | 7.0                   | `:raise`             |

https://github.com/rails/rails/blob/v8.1.1/guides/source/configuring.md?plain=1#L1971-L1993

**`config.action_controller.action_on_path_relative_redirect`**

7.0以降ではなく8.1以降で変更になっています。

> The default value depends on the `config.load_defaults` target version:
> 
> | Starting with version | The default value is |
> | --------------------- | -------------------- |
> | (original)            | `:log`               |
> | 8.1                   | `:raise`             |

https://github.com/rails/rails/blob/v8.1.1/guides/source/configuring.md?plain=1#L1995-L2012