### PR TITLE
Clarify email confirmation message in logs

### DIFF
--- a/guides/source/ja/getting_started.md
+++ b/guides/source/ja/getting_started.md
@@ -1975,7 +1975,7 @@ store(dev)> subscriber = product.subscribers.find_or_create_by(email: "subscribe
 store(dev)> ProductMailer.with(product: product, subscriber: subscriber).in_stock.deliver_later
 ```
 
-メールが送信されたことがRailsの`log/development.log`で以下のように確認できます。
+メールが送信されたことがログで以下のように確認できます。
 
 ```
 ProductMailer#in_stock: processed outbound mail in 63.0ms


### PR DESCRIPTION
Rails consoleでメール送信した場合、log/development.logではなく、コンソール内でログ出力されます。

そのためlog/development.logを削除して単に「ログ」としましたが、より適切な表現があればその方がいいと思います。