### PR TITLE
after_all_transactions_commitの参照リンクを修正

### DIFF
--- a/guides/source/ja/active_record_callbacks.md
+++ b/guides/source/ja/active_record_callbacks.md
@@ -1206,8 +1206,8 @@ end
 `after_all_transactions_commit`に登録したコールバックは、最も外側のトランザクションがコミットされた後にトリガーされます。現在開いているトランザクションのいずれかがロールバックされた場合、そのブロックは呼び出されません。
 コールバックが登録された時点でオープン中のトランザクションが存在しない場合、そのブロックは直ちに実行されます。
 
-[after_all_transactions_commit]
-  : https://api.rubyonrails.org/classes/ActiveRecord.html#method-c-after_all_transactions_commit
+[after_all_transactions_commit]:
+    https://api.rubyonrails.org/classes/ActiveRecord.html#method-c-after_all_transactions_commit
 
 コールバックオブジェクト
 ----------------


### PR DESCRIPTION
[active_record_callbacks.html#activerecord-after-all-transactions-commit](https://railsguides.jp/active_record_callbacks.html#activerecord-after-all-transactions-commit)の参照リンクが壊れているのを発見したため、修正してみました🙇

| before | after(local) |
| --- | --- |
| <img width="668" height="580" alt="image" src="https://github.com/user-attachments/assets/ffb2993c-8fde-4f8e-a9ca-fde846c774c8" /> | <img width="668" height="488" alt="image" src="https://github.com/user-attachments/assets/377e724d-fd93-4507-bd27-4ec1407394bf" /> |