### PR TITLE
[guides] Loginリンクをレイアウトに移動

### DIFF
--- a/guides/source/ja/getting_started.md
+++ b/guides/source/ja/getting_started.md
@@ -1509,7 +1509,7 @@ Log outボタンをクリックすると、indexページのNew productリンク
 オプションとして、先ほどの`app/views/layouts/application.html.erb`レイアウトの`<nav>`セクションに以下のルーティングへのリンクも追加して、認証されていない場合はLoginリンクを表示するようにしてもよいでしょう。
 
 ```erb
-<%# app/views/products/index.html.erb %>
+<%# app/views/layouts/application.html.erb %>
 <%= link_to "Login", new_session_path unless authenticated? %>
 ```
 


### PR DESCRIPTION
# 概要
products/index ではなく layouts/application への記載が正しいかと思いました。ご確認頂けますと幸いです。

# 修正内容

オプションとして、先ほどの`app/views/layouts/application.html.erb`レイアウトの`<nav>`セクションに以下のルーティングへのリンクも追加して、認証されていない場合はLoginリンクを表示するようにしてもよいでしょう。

```erb
<%# app/views/products/index.html.erb %>
<%= link_to "Login", new_session_path unless authenticated? %>

↓

<%# app/views/layouts/application.html.erb %>
<%= link_to "Login", new_session_path unless authenticated? %>
```