### PR TITLE
Update file upload instructions in form_helpers.md

### DIFF
--- a/guides/source/ja/form_helpers.md
+++ b/guides/source/ja/form_helpers.md
@@ -863,7 +863,7 @@ NOTE: 引数の順序は、`collection_select`の場合と`select`の場合で�
 <% end %>
 ```
 
-ファイルアップロードで忘れてはならない重要な点は、レンダリングされるフォームの`enctype`属性を**必ず**`multipart/form-data`に設定しておかなければならない点です。これは、以下のように`form_with`の内側で`file_field_tag`ヘルパーを使えば自動で行われます。`enctype`属性は手動でも設定できます。
+ファイルアップロードで忘れてはならない重要な点は、レンダリングされるフォームの`enctype`属性を**必ず**`multipart/form-data`に設定しておかなければならない点です。これは、`form_with`の内側で`file_field`ヘルパーを使えば自動で行われます。`enctype`属性は手動でも設定できます：
 
 ```erb
 <%= form_with url: "/uploads", multipart: true do |form| %>


### PR DESCRIPTION
Correct the helper method name from `file_field_tag` to `file_field` for clarity.

原文：

https://github.com/yasslab/railsguides.jp/blob/53c72c009072c85d6de134b7bc19fbf92b1010ef/guides/source/form_helpers.md?plain=1#L691

メモ：
form.file_fieldとfile_field_tagの違いとして、form.file_fieldを使うとフォームが自動でmultipartになります。
一方でfile_field_tagを使ってもフォームが自動でmultipartになりません。


