### PR TITLE
Remove an unnecessary code comment

### DIFF
--- a/guides/source/ja/getting_started.md
+++ b/guides/source/ja/getting_started.md
@@ -2198,8 +2198,6 @@ class Product < ApplicationRecord
 
   validates :name, presence: true
   validates :inventory_count, numericality: { greater_than_or_equal_to: 0 }
-
-  # （省略）
 end
 ```
 


### PR DESCRIPTION
Getting Startedを順に進めて行くと、「16.4 共通コードをconcernに抽出する」の段階でのProductモデルは、全てのコードが記載されている状態となり、省略されているコードはありません。
ですので、「# （省略）」を削除しました。
なお、[対応する本家ガイド](https://guides.rubyonrails.org/getting_started.html#extracting-a-concern)の対応部分には、「省略」に相当する記載がないことを確認済みです。