### PR TITLE
[8.1] `engines.md` の翻訳と誤字を修正

### DIFF
--- a/guides/source/ja/engines.md
+++ b/guides/source/ja/engines.md
@@ -333,7 +333,7 @@ end
 
 NOTE: この`has_many`は`Blorgh`モジュールの中にあるクラスの中で定義されています。これだけで、これらのオブジェクトに対して`Blorgh::Comment`モデルを使いたいという意図がRailsに自動的に認識されます。つまり、ここでは`:class_name`オプションでクラス名を指定する必要はありません。
 
-続いて、記事を作成するためのフォームを作成する必要があります。フォームを追加するには、`app/views/blorgh/articles/show.html.erb`の`render @article.comments`呼び出しの直後に以下の行を追加します。
+続いて、記事にコメントを作成できるようにするためのフォームを作成する必要があります。フォームを追加するには、`app/views/blorgh/articles/show.html.erb`の`render @article.comments`呼び出しの直後に以下の行を追加します。
 
 ```erb
 <%= render "blorgh/comments/form" %>
@@ -533,7 +533,7 @@ $ bin/rails generate model user name:string
 </div>
 ```
 
-続いて、エンジンの`Blorgh::ArticleController#article_params`メソッドを更新して、新しいフォームパラメータを受け付けるようにする必要もあります。
+続いて、エンジンの`Blorgh::ArticlesController#article_params`メソッドを更新して、新しいフォームパラメータを受け付けるようにする必要もあります。
 
 ```ruby
 def article_params

--- a/guides/source/ja/engines.md
+++ b/guides/source/ja/engines.md
@@ -333,7 +333,7 @@ end
 
 NOTE: この`has_many`は`Blorgh`モジュールの中にあるクラスの中で定義されています。これだけで、これらのオブジェクトに対して`Blorgh::Comment`モデルを使いたいという意図がRailsに自動的に認識されます。つまり、ここでは`:class_name`オプションでクラス名を指定する必要はありません。
 
-続いて、記事にコメントを作成できるようにするためのフォームを作成する必要があります。フォームを追加するには、`app/views/blorgh/articles/show.html.erb`の`render @article.comments`呼び出しの直後に以下の行を追加します。
+続いて、記事にコメントを作成するためのフォームを作成する必要があります。フォームを追加するには、`app/views/blorgh/articles/show.html.erb`の`render @article.comments`呼び出しの直後に以下の行を追加します。
 
 ```erb
 <%= render "blorgh/comments/form" %>


### PR DESCRIPTION
# 概要

翻訳の修正とタイポの修正をさせて頂きました 🙏 

### 翻訳修正

> 原文
> ... a form so that comments can be created on an article

before: 「...続いて、`記事を作成するためのフォーム`を作成する必要があります」
↓
after: 「...続いて、`記事にコメントを作成するためのフォーム`を作成する必要があります」

# 参考

[3.2 commentsリソースを生成する](https://railsguides.jp/engines.html#comments%E3%83%AA%E3%82%BD%E3%83%BC%E3%82%B9%E3%82%92%E7%94%9F%E6%88%90%E3%81%99%E3%82%8B)

[[英語] 3.2. Generating a Comments Resource](https://guides.rubyonrails.org/v8.1/engines.html#generating-a-comments-resource)